### PR TITLE
hotfix(dose-response): correct hksj_mv field path in both flagships

### DIFF
--- a/ALCOHOL_BC_DOSE_RESP_REVIEW.html
+++ b/ALCOHOL_BC_DOSE_RESP_REVIEW.html
@@ -295,7 +295,7 @@ window.addEventListener('DOMContentLoaded', function () {
     '<div class="kpi"><div class="kpi-label">Knots (g/day)</div><div class="kpi-value">' + rcs.rcs.knots.map(function (k) { return k.toFixed(1); }).join(', ') + '</div></div>' +
     '<div class="kpi"><div class="kpi-label">spline_coefs[0] (linear)</div><div class="kpi-value">' + rcs.rcs.spline_coefs[0].toFixed(5) + '</div><div>SE ' + rcs.rcs.spline_coefs_se[0].toFixed(5) + '</div></div>' +
     '<div class="kpi"><div class="kpi-label">spline_coefs[1] (non-linear)</div><div class="kpi-value">' + rcs.rcs.spline_coefs[1].toFixed(5) + '</div><div>SE ' + rcs.rcs.spline_coefs_se[1].toFixed(5) + '</div></div>' +
-    '<div class="kpi"><div class="kpi-label">Wald non-linearity p</div><div class="kpi-value">' + rcs.rcs.nonlinearity_wald_p.toFixed(4) + '</div><div>(full REML v0.3, HKSJ-mv = ' + (rcs.rcs.hksj_mv != null ? rcs.rcs.hksj_mv.toFixed(2) : 'n/a') + ')</div></div>' +
+    '<div class="kpi"><div class="kpi-label">Wald non-linearity p</div><div class="kpi-value">' + rcs.rcs.nonlinearity_wald_p.toFixed(4) + '</div><div>(full REML v0.3, HKSJ-mv = ' + (rcs.hksj_mv != null ? rcs.hksj_mv.toFixed(2) : 'n/a') + ')</div></div>' +
     '<div class="kpi"><div class="kpi-label">τ² per dimension</div><div class="kpi-value">[' + rcs.rcs.tau2_per_dim.map(function (t) { return t.toExponential(2); }).join(', ') + ']</div></div>' +
     '</div>';
   document.getElementById('rcs-kpis').innerHTML = rcsKpis;
@@ -331,7 +331,7 @@ window.addEventListener('DOMContentLoaded', function () {
     'Engine v0.3.0 uses full multivariate REML via Nelder-Mead on Cholesky parameters of the τ² matrix; ' +
     'non-linearity p matches R mixmeta within |Δ| < 0.05 (engine ≈ 0.7035 vs R ≈ 0.704 on GL-1992). ' +
     'See the R-parity tab for the side-by-side comparison. ' +
-    'HKSJ-multivariate scaling factor: ' + (rcs.rcs.hksj_mv != null ? rcs.rcs.hksj_mv.toFixed(2) : 'n/a') + '; CI critical value t<sub>k-1</sub> = ' + (rcs.tcrit != null ? rcs.tcrit.toFixed(3) : 'n/a') + '.</div>';
+    'HKSJ-multivariate scaling factor: ' + (rcs.hksj_mv != null ? rcs.hksj_mv.toFixed(2) : 'n/a') + '; CI critical value t<sub>k-1</sub> = ' + (rcs.tcrit != null ? rcs.tcrit.toFixed(3) : 'n/a') + '.</div>';
 
   // Load R-precomputed JSON for Tabs 3 and 4
   fetch('outputs/r_validation/doseresp/gl1992_alcohol_bc.json')

--- a/SGLT2I_DOSE_RESP_REVIEW.html
+++ b/SGLT2I_DOSE_RESP_REVIEW.html
@@ -455,7 +455,7 @@ window.addEventListener('DOMContentLoaded', function () {
     '<div class="kpi"><div class="kpi-label">Knots (mg)</div><div class="kpi-value">' + hba1cRcs.rcs.knots.map(function (k) { return k.toFixed(1); }).join(', ') + '</div></div>' +
     '<div class="kpi"><div class="kpi-label">spline_coefs[0] (linear)</div><div class="kpi-value">' + hba1cRcs.rcs.spline_coefs[0].toFixed(5) + '</div><div>SE ' + hba1cRcs.rcs.spline_coefs_se[0].toFixed(5) + '</div></div>' +
     '<div class="kpi"><div class="kpi-label">spline_coefs[1] (non-linear)</div><div class="kpi-value">' + hba1cRcs.rcs.spline_coefs[1].toFixed(5) + '</div><div>SE ' + hba1cRcs.rcs.spline_coefs_se[1].toFixed(5) + '</div></div>' +
-    '<div class="kpi"><div class="kpi-label">Wald non-linearity p</div><div class="kpi-value">' + hba1cRcs.rcs.nonlinearity_wald_p.toFixed(4) + '</div><div>(full REML v0.3, HKSJ-mv = ' + (hba1cRcs.rcs.hksj_mv != null ? hba1cRcs.rcs.hksj_mv.toFixed(2) : 'n/a') + ')</div></div>' +
+    '<div class="kpi"><div class="kpi-label">Wald non-linearity p</div><div class="kpi-value">' + hba1cRcs.rcs.nonlinearity_wald_p.toFixed(4) + '</div><div>(full REML v0.3, HKSJ-mv = ' + (hba1cRcs.hksj_mv != null ? hba1cRcs.hksj_mv.toFixed(2) : 'n/a') + ')</div></div>' +
     '<div class="kpi"><div class="kpi-label">τ² per dim</div><div class="kpi-value">[' + hba1cRcs.rcs.tau2_per_dim.map(function (t) { return t.toExponential(2); }).join(', ') + ']</div></div>' +
     '</div>';
 
@@ -488,7 +488,7 @@ window.addEventListener('DOMContentLoaded', function () {
     ' (df = ' + (hba1cRcs.rcs.spline_coefs.length - 1) + ', χ² = ' + (hba1cRcs.rcs.nonlinearity_wald_chi2 != null ? hba1cRcs.rcs.nonlinearity_wald_chi2.toFixed(3) : 'n/a') + '). ' +
     'Engine v0.3.0 uses full multivariate REML via Nelder-Mead on Cholesky parameters of the τ² matrix; ' +
     'non-linearity p matches R mixmeta within |Δ| < 0.05 — see the R-parity tab for the side-by-side comparison. ' +
-    'HKSJ-multivariate scaling factor: ' + (hba1cRcs.rcs.hksj_mv != null ? hba1cRcs.rcs.hksj_mv.toFixed(2) : 'n/a') + '; CI critical value t<sub>k-1</sub> = ' + (hba1cRcs.tcrit != null ? hba1cRcs.tcrit.toFixed(3) : 'n/a') + '.</div>';
+    'HKSJ-multivariate scaling factor: ' + (hba1cRcs.hksj_mv != null ? hba1cRcs.hksj_mv.toFixed(2) : 'n/a') + '; CI critical value t<sub>k-1</sub> = ' + (hba1cRcs.tcrit != null ? hba1cRcs.tcrit.toFixed(3) : 'n/a') + '.</div>';
 
   // Load R-precomputed JSON for HbA1c (Tabs 3 + 5a) and hHF (Tabs 4-secondary + 5b).
   Promise.all([


### PR DESCRIPTION
## Summary

PRs #247 (Round 2C badge work) and #248 (GL-1992 restoration) introduced a field-path bug in both flagships: the Wald non-linearity KPI footer and the green-badge inline note read \`hksj_mv\` via \`result.rcs.hksj_mv\` (nested), but the engine emits it at \`result.hksj_mv\` (top-level). The flagships were therefore displaying \"HKSJ-mv = n/a\" instead of the real values.

Caught by an end-to-end double-check that ran fitRCS on both fixtures in Node and compared the actual return-object surface to what the flagship code reads. Hotfix changes \`*.rcs.hksj_mv\` → \`*.hksj_mv\` at 4 spots (2 per flagship).

## Verified end-to-end (post-fix)

| Fixture | HKSJ-mv | tcrit | chi² | engine p | R p | \|Δ\| | Badge |
|---|---|---|---|---|---|---|---|
| SGLT2i HbA1c | 1.08 | 4.303 (k=3) | 1.445 | 0.2271 | 0.2293 | 0.0022 | **GREEN** |
| GL-1992 | 1.56 | 2.776 (k=5) | 0.145 | 0.7035 | 0.7069 | 0.0034 | **GREEN** |

Both flagships' R-parity badge non-linearity-p rows now correctly evaluate \`|engine − R| < 0.05\` and render green.

## Reference: engine v0.3.0 fitRCS return shape

Top-level fields (correct access): \`hksj_mv\`, \`tcrit\`, \`q_mv\`, \`df_mv\`, \`estimator\`, \`ci_method\`, \`converged\`, \`iterations\`, \`pooled_slope_log\` family

Nested under \`.rcs\` (correct access): \`nonlinearity_wald_p/chi2/df\`, \`tau2_matrix\`, \`tau2_per_dim\`, \`spline_coefs\`, \`spline_coefs_se\`, \`fit_at_dose\`, \`reml_converged/iterations/loglik\`, \`cov_beta\`

## Test plan

- [x] End-to-end Node simulation on both fixtures
- [x] grep: 0 remaining \`.rcs.hksj_mv\` accesses
- [x] All 4 corrected sites read top-level \`hksj_mv\` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)