### PR TITLE
ci(dose-response): add 3-layer test workflow (engine + contract + Playwright)

### DIFF
--- a/.github/workflows/dose_response.yml
+++ b/.github/workflows/dose_response.yml
@@ -1,0 +1,88 @@
+name: Dose-response engine + flagships
+
+# Runs the 3-layer dose-response test stack on every PR or push touching
+# any dose-response surface. Catches:
+#   Layer 1 — engine numerics (60 unit tests)
+#   Layer 2 — flagship field-path contract (128 assertions; Round 2C bug class)
+#   Layer 3 — Playwright real-browser smoke (16 assertions; CSP class)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'rapidmeta-dose-response-engine-v1.js'
+      - 'vendor/r-validation-doseresp.js'
+      - 'vendor/r-validation-badge.js'
+      - '*_DOSE_RESP_REVIEW.html'
+      - '*_DOSE_RESP_REVIEW.js'
+      - 'tests/dose_response_fixtures/**'
+      - 'tests/test_dose_response_engine.mjs'
+      - 'tests/test_flagship_field_paths.mjs'
+      - 'tests/test_flagship_playwright_smoke.py'
+      - 'fixtures/dose_response/**'
+      - 'outputs/r_validation/doseresp/**'
+      - 'scripts/r_validate_doseresp.py'
+      - 'scripts/r_validate_doseresp.R'
+      - '.github/workflows/dose_response.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'rapidmeta-dose-response-engine-v1.js'
+      - 'vendor/r-validation-doseresp.js'
+      - 'vendor/r-validation-badge.js'
+      - '*_DOSE_RESP_REVIEW.html'
+      - '*_DOSE_RESP_REVIEW.js'
+      - 'tests/dose_response_fixtures/**'
+      - 'tests/test_dose_response_engine.mjs'
+      - 'tests/test_flagship_field_paths.mjs'
+      - 'tests/test_flagship_playwright_smoke.py'
+      - 'fixtures/dose_response/**'
+      - 'outputs/r_validation/doseresp/**'
+      - 'scripts/r_validate_doseresp.py'
+      - 'scripts/r_validate_doseresp.R'
+      - '.github/workflows/dose_response.yml'
+  workflow_dispatch:
+
+jobs:
+  layer-1-engine:
+    name: Engine unit tests (Node)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Run engine test suite
+        run: node tests/test_dose_response_engine.mjs
+
+  layer-2-contract:
+    name: Flagship field-path contract (Node, no browser)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: layer-1-engine
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Run contract test
+        run: node tests/test_flagship_field_paths.mjs
+
+  layer-3-playwright:
+    name: Real-browser smoke (Python Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: layer-2-contract
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install Playwright + Chromium
+        run: |
+          pip install playwright
+          playwright install chromium
+          playwright install-deps chromium
+      - name: Run Playwright smoke
+        run: python tests/test_flagship_playwright_smoke.py


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/dose_response.yml\` — a dedicated CI workflow that runs the 3-layer dose-response test stack on every PR or push touching engine source, flagship HTML/JS, fixtures, R precomputes, or validation scripts.

| Layer | Runner | Assertions | Catches |
|---|---|---|---|
| 1 — Engine unit | Node 22 | 60 | Numerics regressions (Nelder-Mead, REML, Q-profile, etc.) |
| 2 — Field-path contract | Node 22 | 128 (32 × 4 flagships) | Top-level vs nested field-path bugs (Round 2C class) |
| 3 — Real-browser smoke | Python 3.13 + Playwright Chromium | 16 (4 × 4 flagships) | CSP / inline-script / async-render bugs |

Sequential gating (Layer 1 must pass before Layer 2, etc.) keeps fast cheap tests as the first line of defense. Path filter restricts to dose-response surfaces — unrelated portfolio changes won't trigger.

## Background

The Round 2A → Round 3 work shipped a CSP regression that broke all 3 flagships in real browsers (Firefox/Safari with strict CSP would have silently lost tab nav, KPI displays, and the R-parity badge mount). It went undetected for weeks because every prior verification was Node-side simulation or HTTP-200 smoke. PR #257 fixed it; this PR ensures it can't recur silently.

## Test plan

- [x] Workflow YAML parses cleanly (verified by GitHub on push)
- [x] All 3 test commands run green locally on \`main\`:
  - \`node tests/test_dose_response_engine.mjs\` → 60 / 60
  - \`node tests/test_flagship_field_paths.mjs\` → 128 / 128
  - \`python tests/test_flagship_playwright_smoke.py\` → 16 / 16
- [ ] First CI run after merge / on this PR shows all 3 jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)