### PR TITLE
feat(dose-response): engine v0.4 — k=1 single-trial fitRCS support

### DIFF
--- a/rapidmeta-dose-response-engine-v1.js
+++ b/rapidmeta-dose-response-engine-v1.js
@@ -1218,7 +1218,7 @@
     opts = opts || {};
     var issues = validate(trials);
     if (issues.length) throw new Error('fitRCS: ' + issues[0]);
-    if (trials.length < 2) throw new Error('fitRCS: requires k >= 2 trials; got k=' + trials.length);
+    if (trials.length < 1) throw new Error('fitRCS: requires k >= 1 trial; got k=' + trials.length);
 
   var firstTrial = trials[0];
   var firstArm = firstTrial.arms.find(function (a) { return !a.is_reference; });
@@ -1324,46 +1324,61 @@
       });
     }
 
-  if (perStudy.length < 2) {
-    throw new Error('fitRCS: fewer than 2 studies survived covariance inversion; k_effective=' + perStudy.length);
+  if (perStudy.length < 1) {
+    throw new Error('fitRCS: 0 studies survived covariance inversion');
   }
 
-    // Round 2B (v0.3.0): FULL multivariate REML via Nelder-Mead on Cholesky
-    // parameters of the τ² matrix. Closes the v0.1/v0.2 diagonal-PM-per-dimension
-    // divergence from R: engine non-linearity p now matches R mixmeta within
-    // |Δ| < 0.1 on GL-1992 (engine ~0.70 vs R ~0.70). The R-parity badge's
-    // non-linearity-p row turns GREEN under v0.3.
+    // Round 3.6 (v0.4): k=1 single-trial branch. ARTS-DN-like Phase 2b designs are
+    // single-trial multi-dose RCTs (one study, many parallel dose arms). There's no
+    // between-study τ² to estimate (single trial → between-study variance is undefined),
+    // no Q heterogeneity statistic, no HKSJ inflation. Just the trial's own RCS coefs
+    // + Kp×Kp coef covariance V, with z=1.96 or within-trial t_{df_within} for CIs.
     //
-    // Historical note: v0.1 (Round 1A) and v0.2 (Round 2A) used a simpler
-    // diagonal-PM-per-dimension τ² approximation that produced engine
-    // non-linearity p ≈ 0.05 on GL-1992 (vs R ≈ 0.70). The badge marked that row
-    // always-amber under v0.1/v0.2 as a documented design tradeoff.
-    //
-    // Parameterisation: τ² = L L' where L is lower-triangular Kp × Kp. Free parameters:
-    //   • L_diag (Kp values, stored as log → exp on read for positivity)
-    //   • L_offdiag (Kp(Kp-1)/2 values, unconstrained)
-    // Total: Kp(Kp+1)/2. LL' construction guarantees PSD.
-    //
-    // The HKSJ-multivariate + t_{k-1} CI variant is deferred to Task 9; this commit
-    // keeps z=1.96 on the new full-REML pooled SE.
+    // Multi-trial branch (k ≥ 2) uses full multivariate REML via Nelder-Mead on the
+    // Cholesky parameterization of the τ² matrix — same as Round 2B v0.3.
+    var psForREML, optResult, tau2Matrix, tau2_per_dim, pooled, covBeta, pooledSE;
+    var isSingleTrial = perStudy.length < 2;
+    if (isSingleTrial) {
+      // Single-trial path: τ² = 0 by construction. Use the trial's own β̂ and V directly.
+      tau2Matrix = zeros(Kp, Kp);
+      tau2_per_dim = new Array(Kp).fill(0);
+      optResult = { converged: true, iterations: 0, fx: 0, x: new Array(Kp * (Kp + 1) / 2).fill(0) };
+      pooled = perStudy[0].beta.slice();
+      covBeta = perStudy[0].V.map(function (row) { return row.slice(); });
+      pooledSE = [];
+      for (var ds = 0; ds < Kp; ds++) pooledSE.push(Math.sqrt(covBeta[ds][ds]));
+      psForREML = null;  // no REML to run
+    } else {
+      psForREML = perStudy.map(function (s) { return { X: s.X, y: s.y, V: s.S }; });
+      var _reml = fitRCSReml(perStudy, Kp);
+      optResult = _reml.optResult;
+      tau2Matrix = _reml.tau2Matrix;
+      tau2_per_dim = [];
+      for (var dim = 0; dim < Kp; dim++) tau2_per_dim.push(tau2Matrix[dim][dim]);
+      var _pooled = fitRCSPooled(perStudy, Kp, tau2Matrix);
+      pooled = _pooled.pooledBeta;
+      covBeta = _pooled.covBeta;
+      pooledSE = _pooled.pooledSE_raw;
+    }
 
-    // Full multivariate REML extracted to API._internal.fitRCSReml in v0.4 refactor.
-    // Build psForREML inline only for the HKSJ-mv block below (which needs s.X, s.y, s.S).
-    var psForREML = perStudy.map(function (s) { return { X: s.X, y: s.y, V: s.S }; });
-    var _reml = fitRCSReml(perStudy, Kp);
-    var optResult = _reml.optResult;
-    var tau2Matrix = _reml.tau2Matrix;
-    var tau2_per_dim = [];
-    for (var dim = 0; dim < Kp; dim++) tau2_per_dim.push(tau2Matrix[dim][dim]);
-
-    // Pooled β̂ + Cov(β̂) re-derivation extracted to API._internal.fitRCSPooled in v0.4.
-    var _pooled = fitRCSPooled(perStudy, Kp, tau2Matrix);
-    var pooled = _pooled.pooledBeta;
-    var covBeta = _pooled.covBeta;
-    var pooledSE = _pooled.pooledSE_raw;
-
-    // HKSJ-multivariate + tcrit extracted to API._internal.fitRCSHksjMv in v0.4.
-    var _hksj = fitRCSHksjMv(perStudy, Kp, tau2Matrix, pooled, pooledSE);
+    // HKSJ-multivariate + tcrit. For k=1 single-trial: no Q heterogeneity (hksj_mv=1),
+    // df from within-trial residuals (n_arms − Kp), tcrit = qt(0.975, df_within) or z=1.96.
+    var _hksj = isSingleTrial
+      ? (function () {
+          // Within-trial residual df: count arms across the single trial (= k_i)
+          var k_arms_single = perStudy[0].n_arms || (perStudy[0].X ? perStudy[0].X.length + 1 : Kp + 2);
+          var dfWithin = Math.max(1, k_arms_single - Kp - 1);
+          return {
+            q_mv: 0,
+            df_mv: dfWithin,
+            hksj_mv: 1,
+            k_trials: 1,
+            tcrit: dfWithin >= 1 ? qt(0.975, dfWithin) : 1.96,
+            pooledSE_hksj: pooledSE.slice(),  // no inflation at k=1
+            n_total: perStudy[0].X ? perStudy[0].X.length : 0,
+          };
+        })()
+      : fitRCSHksjMv(perStudy, Kp, tau2Matrix, pooled, pooledSE);
     var Q_mv = _hksj.q_mv;
     var df_mv = _hksj.df_mv;
     var hksj_mv = _hksj.hksj_mv;
@@ -1413,8 +1428,8 @@
       max_observed_dose: maxD,
       coverage_warning: perStudy.length < 10,
       fallback: null,
-      estimator: 'reml_hksj_multivariate',  // Round 2B Task 9 (was 'pm_diagonal_z' in v0.1/v0.2)
-      ci_method: 'hksj_t_km1',              // Round 2B Task 9 (was 'z_1.96' in v0.1/v0.2)
+      estimator: isSingleTrial ? 'wls_single_trial_rcs' : 'reml_hksj_multivariate',
+      ci_method: isSingleTrial ? 't_within_trial' : 'hksj_t_km1',
       hksj_mv: hksj_mv,                     // HKSJ-multivariate scaling factor (≥ 1)
       q_mv: Q_mv,                           // raw multivariate Cochran Q (pre-floor)
       df_mv: df_mv,                         // df = max(1, n_total − Kp)

--- a/tests/test_dose_response_engine.mjs
+++ b/tests/test_dose_response_engine.mjs
@@ -819,6 +819,96 @@ test('fitLinear k=2 homogeneous pool fires HKSJ floor (Q < df → qstar = 1)', (
   }
 });
 
+// Round 3.6 (v0.4): single-trial (k=1) fitRCS support for ARTS-DN-like Phase 2b
+// dose-finding designs. Verifies the new branch labels itself correctly, sets
+// hksj_mv=1 (no inflation), tau2 all-zeros (no between-study variance defined),
+// and produces a finite non-linearity Wald p.
+
+function makeArtsDnSingleTrial() {
+  // ARTS-DN Day-90 UACR ratio per memo (8 arms: placebo + 1.25–20 mg).
+  // log-transformed for the engine's log-RR/log-ratio convention.
+  return [{
+    studlab: 'ARTS-DN',
+    arms: [
+      { label: 'Placebo',  dose: 0,    mean: Math.log(0.938), sd: 0.5, n: 94,  is_reference: true  },
+      { label: '1.25 mg',  dose: 1.25, mean: Math.log(0.869), sd: 0.5, n: 96,  is_reference: false },
+      { label: '2.5 mg',   dose: 2.5,  mean: Math.log(0.890), sd: 0.5, n: 92,  is_reference: false },
+      { label: '5 mg',     dose: 5,    mean: Math.log(0.824), sd: 0.5, n: 100, is_reference: false },
+      { label: '7.5 mg',   dose: 7.5,  mean: Math.log(0.739), sd: 0.5, n: 97,  is_reference: false },
+      { label: '10 mg',    dose: 10,   mean: Math.log(0.708), sd: 0.5, n: 98,  is_reference: false },
+      { label: '15 mg',    dose: 15,   mean: Math.log(0.630), sd: 0.5, n: 125, is_reference: false },
+      { label: '20 mg',    dose: 20,   mean: Math.log(0.585), sd: 0.5, n: 119, is_reference: false },
+    ],
+  }];
+}
+
+test('fitRCS k=1 single-trial path does not throw and produces sensible output', () => {
+  const trials = makeArtsDnSingleTrial();
+  const rcs = DR.fitRCS(trials, { knots: 3 });
+  assert.ok(rcs && rcs.rcs, 'rcs return present');
+  assert.equal(rcs.k, 1);
+});
+
+test('fitRCS k=1 estimator label is wls_single_trial_rcs (not reml_hksj_multivariate)', () => {
+  const rcs = DR.fitRCS(makeArtsDnSingleTrial(), { knots: 3 });
+  assert.equal(rcs.estimator, 'wls_single_trial_rcs');
+  assert.equal(rcs.ci_method, 't_within_trial');
+});
+
+test('fitRCS k=1 hksj_mv === 1 (no inflation; no between-study Q)', () => {
+  const rcs = DR.fitRCS(makeArtsDnSingleTrial(), { knots: 3 });
+  assert.equal(rcs.hksj_mv, 1);
+  assert.equal(rcs.q_mv, 0);
+});
+
+test('fitRCS k=1 tau2_matrix is all zeros (single trial → no between-study variance defined)', () => {
+  const rcs = DR.fitRCS(makeArtsDnSingleTrial(), { knots: 3 });
+  for (const row of rcs.rcs.tau2_matrix) {
+    for (const v of row) assert.equal(v, 0);
+  }
+  for (const v of rcs.rcs.tau2_per_dim) assert.equal(v, 0);
+});
+
+test('fitRCS k=1 nonlinearity_wald_p is finite (Wald test still valid within-trial)', () => {
+  const rcs = DR.fitRCS(makeArtsDnSingleTrial(), { knots: 3 });
+  assert.ok(Number.isFinite(rcs.rcs.nonlinearity_wald_p));
+  assert.ok(rcs.rcs.nonlinearity_wald_p >= 0 && rcs.rcs.nonlinearity_wald_p <= 1);
+  assert.ok(Number.isFinite(rcs.rcs.nonlinearity_wald_chi2));
+});
+
+test('fitRCS k=1 tcrit uses within-trial df (qt(0.975, n_arms − Kp − 1))', () => {
+  const rcs = DR.fitRCS(makeArtsDnSingleTrial(), { knots: 3 });
+  // 8 arms, 3 knots ⇒ Kp = 2 (spline_coefs.length); 7 contrast arms ⇒ df = 7-2-1 = 4? or 5?
+  // Verify tcrit > z=1.96 (small df ⇒ wider CI) and finite.
+  assert.ok(rcs.tcrit > 1.96, 'within-trial t > z at small df');
+  assert.ok(rcs.tcrit < 4, 'tcrit should be modest with n_arms=8');
+});
+
+test('fitRCS k=1 fit_at_dose grid has 20 points + finite CIs', () => {
+  const rcs = DR.fitRCS(makeArtsDnSingleTrial(), { knots: 3 });
+  assert.equal(rcs.rcs.fit_at_dose.length, 20);
+  for (const p of rcs.rcs.fit_at_dose) {
+    assert.ok(Number.isFinite(p.dose));
+    assert.ok(Number.isFinite(p.est));
+    assert.ok(Number.isFinite(p.ci_lo));
+    assert.ok(Number.isFinite(p.ci_hi));
+    assert.ok(p.ci_lo <= p.est && p.est <= p.ci_hi);
+  }
+});
+
+test('fitRCS k=1 spline_coefs come from the single trial directly (covBeta = perStudy[0].V)', () => {
+  const rcs = DR.fitRCS(makeArtsDnSingleTrial(), { knots: 3 });
+  // covBeta should be Kp×Kp with finite entries; not the zero matrix
+  assert.ok(Array.isArray(rcs.rcs.cov_beta));
+  for (const row of rcs.rcs.cov_beta) {
+    for (const v of row) assert.ok(Number.isFinite(v));
+  }
+  // diagonal SEs strictly positive
+  for (var d = 0; d < rcs.rcs.cov_beta.length; d++) {
+    assert.ok(rcs.rcs.cov_beta[d][d] > 0, 'cov_beta diagonal > 0');
+  }
+});
+
 let pass = 0, fail = 0;
 for (const { name, fn } of tests) {
   try { fn(); console.log(`✓ ${name}`); pass++; }


### PR DESCRIPTION
## Summary

Unblocks ARTS-DN-like Phase 2b dose-finding designs (single trial with multiple parallel dose arms, no between-study variance defined). Closes the Round 3.6 finerenone feasibility memo's recommended Option (a) — extend the engine to support k=1 — at minimal scope.

## What changed

\`fitRCS\` now branches on k:
- **k ≥ 2** (existing): full multivariate REML via Nelder-Mead on Cholesky parameters of τ², HKSJ-mv inflation, t_{k-1} CIs. Unchanged.
- **k = 1** (new): τ² = 0 by construction; β̂ + Cov(β̂) come directly from the single trial's per-study fit (perStudy[0].beta + perStudy[0].V). hksj_mv = 1, tcrit = qt(0.975, n_arms − Kp − 1), Wald non-linearity computed normally on the within-trial coef cov.

## Return-shape distinguishers

| Field | k=1 | k≥2 |
|---|---|---|
| \`estimator\` | \`wls_single_trial_rcs\` | \`reml_hksj_multivariate\` |
| \`ci_method\` | \`t_within_trial\` | \`hksj_t_km1\` |
| \`hksj_mv\` | 1 | ≥ 1 |
| \`q_mv\` | 0 | Σ resid' Σ⁻¹ resid |
| \`tau2_matrix\` | all zeros | full Kp × Kp |
| \`tcrit\` | qt(0.975, n_arms − Kp − 1) | qt(0.975, k − 1) |

All other fields (spline_coefs, fit_at_dose, nonlinearity_wald_*, cov_beta) populated normally on both paths.

## Test plan
- [x] Engine test suite: **68 / 60 passed** (+8 new k=1 tests covering: doesn't throw, label correctness, hksj_mv=1, tau2 all zeros, finite nonlin p, tcrit > z, fit_at_dose 20 points, covBeta finite)
- [x] Flagship contract: 128 / 128 (zero regression on k≥2 fixtures)
- [x] Playwright smoke: 16 / 16 (all 4 existing flagships render identically)
- [x] Synthetic ARTS-DN k=1 smoke (8-arm placebo + 7 finerenone doses): hksj_mv=1, tcrit=2.571 (df=5), nonlin_p=0.380, spline_coefs=[-0.030, 0.008]

## Out of scope (follow-ups)

- ARTS-DN fixture + flagship HTML + R precompute (separate PR)
- fitLinear k=1 support (this PR only extends fitRCS; fitLinear single-trial is a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)