### PR TITLE
Round 3.6: FINERENONE_ARTS_DN flagship (k=1 single-trial dose-response)

### DIFF
--- a/tests/test_flagship_playwright_smoke.py
+++ b/tests/test_flagship_playwright_smoke.py
@@ -334,4 +334,22 @@ def main():
                                 f"engine_version span text {engine_version!r} does not contain '0.3.0'"
                             )
                             print(f"  ✓ engine v0.3.0 label rendered: {engine_version!r}")
-              
+                            passed += 1
+                        except AssertionError as e:
+                            print(f"  ✗ {e}")
+                            failed += 1
+                    finally:
+                        page.close()
+            finally:
+                browser.close()
+    finally:
+        srv.shutdown()
+        srv.server_close()
+        print(f"\nHTTP server stopped.")
+
+    print(f"\n{'=' * 60}\n{passed} passed, {failed} failed")
+    sys.exit(0 if failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Round 3.6 flagship for the Finrenone dose-response pack: a single-trial (k=1) dose-response review of **ARTS-DN** (NCT01874431; Bakris GL et al., JAMA 2015 — PMID 26325557 — DOI 10.1001/jama.2015.10081), the Phase 2b finerenone dose-finder (8 arms: placebo + 1.25 / 2.5 / 5 / 7.5 / 10 / 15 / 20 mg; N = 821; Day-90 UACR / baseline ratio as the registered primary outcome).

Exercises the engine v0.4 k=1 single-trial branch shipped in PR #270 (commit 40990cf41):
- `estimator = wls_single_trial_rcs`
- `ci_method = t_within_trial`
- `hksj_mv = 1` by construction (no Q heterogeneity defined at k=1)
- `tau2_matrix = zeros(Kp, Kp)` by construction (between-study variance undefined with one trial)
- `tcrit = qt(0.975, n_arms - Kp - 1) = qt(0.975, 5) = 2.571` (within-trial residual t)
- `converged = true, reml_iterations = 0` (no REML to run; closed-form WLS on the trial's own V)

### Headline

- Engine RCS pool: `spline_coefs[0] = -0.030` (linear, SE 0.011), `spline_coefs[1] = 0.008` (non-linear, SE 0.013). Wald non-linearity p = 0.561 — within-trial dose-response is approximately log-linear over 1.25 - 20 mg.
- Model-fit UACR ratio at 20 mg = 0.621 (95% CI 0.511 to 0.755), matching the published primary outcome (0.62 [90% CI 0.54 - 0.72]).
- R-parity (RCS-only abbreviated): spline_coefs[0] |Δ| = 0.0002, spline_coefs[1] |Δ| = 0.00016, non-linearity p |Δ| = 0.011 — all 3 RCS-layer rows GREEN against R dosresmeta.

### Tabs (3, per spec)

1. **UACR — RCS dose-response (HEADLINE)** — 3-knot Harrell-default, KPIs (spline_coefs, tcrit, df, hksj_mv=1), Wald non-linearity p, per-arm forest (8 arms with placebo-corrected UACR ratios + 95% CI), tau² matrix display (zeros), 20-point fit_at_dose grid (back-transformed to ratio scale), plain-English summary.
2. **AACT data audit** — trial metadata (NCT01874431, ARTS-DN, Bakris 2015 JAMA, PMID 26325557, AACT outcome_id 211099820), per-arm raw multiplicative-ratio + 90% CI + N + log-scale SE, conversion notes (`SE_log = (log_CI_hi - log_CI_lo) / (2 * 1.6449)`; `SD = SE * sqrt(n)`), inline PubMed abstract.
3. **R-parity badge (k=1 deferral)** — custom `rv-badge-deferred` panel with documented k=1 deferral notice + abbreviated 2-row RCS-only engine-vs-R comparison plus the non-linearity-p row. Standard 5-row badge can't run at k=1 (engine fitLinear requires k ≥ 2; R lme4::lmer requires ≥ 2 sampled grouping levels — both confirmed in R precompute output). Deferred to engine v0.5.

### Dropped tabs (vs Tirzepatide / SGLT2i / Alcohol flagships)

- **Linear pool tab** — engine `fitLinear` requires k ≥ 2 and throws at k=1 by design. The RCS linear-basis component (`spline_coefs[0]`) serves the linear-effect summary directly in Tab 1.
- **One-stage tab** — R `lme4::lmer` requires ≥ 2 sampled grouping levels for the random study intercept to identify variance; at k=1 it raises *"grouping factors must have > 1 sampled level"* (confirmed in R precompute: `one_stage.fit_ok = false; error_msg = "grouping factors must have > 1 sampled level"`).

### Files

- `FINERENONE_ARTS_DN_DOSE_RESP_REVIEW.html` (194 lines, CSP-strict, sibling-`.js` loaded `defer`, no inline `<script>` or `onclick`)
- `FINERENONE_ARTS_DN_DOSE_RESP_REVIEW.js` (365 lines, full Tab 1/2/3 wiring + abstract + R-parity deferral panel)
- `tests/dose_response_fixtures/finerenone_arts_dn.json` (8-arm fixture, AACT 2026-04-12 source, log-scale conversions documented)
- `fixtures/dose_response/finerenone_arts_dn_abstracts.json` (PMID 26325557 PubMed metadata — verified via MCP; documents the published-abstract "25 mg" typo corrected to 20 mg per primary-outcome paragraph + AACT arm OG006)
- `outputs/r_validation/doseresp/finerenone_arts_dn.json` (R dosresmeta 2.2.0 precompute: linear `pooled_slope_log = -0.024`, RCS spline_coefs `[-0.030, 0.008]`, non-linearity p = 0.550; one_stage `fit_ok = false` with the documented lme4 error)
- `tests/test_flagship_field_paths.mjs` (+ `singleTrial: true` contract entry — adds 28 tests including the k=1 invariants: hksj_mv=1, tau2 all-zeros, reml_iterations=0, tcrit > 1.96, cov_beta finite + positive diagonal)
- `tests/test_flagship_playwright_smoke.py` (+ `expected_badge = "deferred"` path and `assert_badge_is_deferred` helper — checks `rv-badge-deferred` class + "deferred to engine v0.5" deferral note presence; restores truncated tail of `main()` from prior commit)

### Test plan

- [x] `node tests/test_dose_response_engine.mjs` — **68 / 68 passed** (unchanged; 8 dedicated k=1 unit tests already in place from PR #270)
- [x] `node tests/test_flagship_field_paths.mjs` — **156 / 156 passed** (was 128; +28 from new singleTrial-aware flagship entry)
- [x] `python tests/test_flagship_playwright_smoke.py` — **20 / 20 passed** (was 16; +4 for FINERENONE_ARTS_DN: no console errors, no `n/a` KPI bugs, badge `rv-badge-deferred` with deferral note, engine v0.3.0 label rendered)

### Engine field-path verification

- TOP-LEVEL (matches Round 2C PR #250 contract): `hksj_mv`, `tcrit`, `q_mv`, `df_mv`, `estimator`, `ci_method`, `converged`, `pooled_slope_log{,_se,_ci_lo,_ci_hi}` — all assertion-pinned.
- NESTED under `.rcs`: `spline_coefs`, `spline_coefs_se`, `nonlinearity_wald_{p,chi2,df}`, `tau2_matrix`, `tau2_per_dim`, `fit_at_dose`, `cov_beta`, `reml_{converged,iterations,loglik}` — all assertion-pinned.

### PubMed verification

PMID 26325557 confirmed via `mcp__claude_ai_PubMed__get_article_metadata` on 2026-05-14 — Bakris GL et al., "Effect of Finerenone on Albuminuria in Patients With Diabetic Nephropathy: A Randomized Clinical Trial", JAMA 2015;314(9):884-94, DOI [10.1001/jama.2015.10081](https://doi.org/10.1001/jama.2015.10081). Authors, title, volume/issue/pages, and registered NCT01874431 all match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)