### PR TITLE
feat(dose-response): Round 3.9 — BRODALUMAB_PSORIASIS_AMAGINE flagship (k=3 binary PASI75; engine refuses RCS where R fits with degenerate knots)

### DIFF
--- a/BRODALUMAB_PSORIASIS_AMAGINE_DOSE_RESP_REVIEW.js
+++ b/BRODALUMAB_PSORIASIS_AMAGINE_DOSE_RESP_REVIEW.js
@@ -12,7 +12,7 @@
  *     gap in the underlying trials is 60-80pp because the response curve
  *     is non-linear and saturating, see Tab 2 caveat).
  *     τ² ≈ 8.6e-7 (effectively zero); Q ≈ 6.56 (df 2); I² ≈ 70%;
- *     HKSJ adj ≈ 1.81 (HKSJ inflates the SE moderately because Q*/df > 1).
+ *     HKSJ adj ≈ 1.81 (HKSJ inflates the SE moderately because Q-star over df is greater than 1).
  *
  *   RCS layer: ENGINE REFUSES, returns layer='linear', fallback='degenerate_to_linear',
  *     rcs=null. The cross-trial dose grid has only 2 distinct positive doses

--- a/tests/test_flagship_playwright_smoke.py
+++ b/tests/test_flagship_playwright_smoke.py
@@ -161,6 +161,50 @@ FLAGSHIPS = [
         "allowed_amber_rows": [],
         "deferral_must_contain": "deferred to engine v0.5",
     },
+    {
+        # Round 3.9 — 3-trial AMAGINE brodalumab PASI 75 binary dose-response flagship.
+        # FIRST flagship where engine declines RCS but R FITS RCS (the prior
+        # degeneracy flagships SUSTAIN and SELECT had both engines refusing via
+        # different paths). The 3 trials use a {0, 140, 210} mg dose grid that
+        # has only 2 distinct positive doses; the engine's `rcsKnots` returns
+        # fewer than K=3 distinct knot locations and `fitRCS` short-circuits to
+        # `fitLinear` with `fallback='degenerate_to_linear'`, `rcs=null`. R
+        # `dosresmeta` does NOT short-circuit — each trial has 2 non-reference
+        # arms after Option A active-comparator dropping (>= K_p=2 required),
+        # so R's sparse-per-trial-arm guard does not fire. R proceeds and fits
+        # a 3-knot RCS with all 3 percentile knots inside the 140–210 mg
+        # interval (knots [157.5, 175, 192.5], spline_coefs [0.01763, -0.01875],
+        # nonlinearity_wald_p 1.64e-13). The R fit is technically valid arithmetic
+        # but uses degenerate (uninformative) knots.
+        # Badge characteristics (custom panel, NOT the standard 5-row badge):
+        #   - header class `rv-badge-deferred` (purple) — overall flag for the
+        #     engine-vs-R disagreement
+        #   - linear-slope row GREEN (engine 0.00523 vs R 0.00735, |Δ| ≈ 0.0021
+        #     well within the 0.01 threshold)
+        #   - linear-τ² row GREEN (both essentially zero; engine PM 8.6e-7 vs
+        #     R REML 4.6e-19, |Δ| ≈ 8.6e-7 well within the 0.0001 threshold)
+        #   - 3 RCS rows custom "ENGINE-DECLINED / R-FIT" status (rv-row-deferred
+        #     styling; status cell explicitly contains "ENGINE-DECLINED / R-FIT")
+        #   - one-stage row PASS-THROUGH (R glmer converged=false)
+        # KPI scope here is Tab 2's `rcs-note-body` (containing the side-by-side
+        # engine-output / R-output code blocks); we re-use the standard 'no n/a
+        # in KPI' check (the standard 'pasi-rcs-kpis' mount does not exist on
+        # this flagship — Tab 2 is the methodological note).
+        "html": "BRODALUMAB_PSORIASIS_AMAGINE_DOSE_RESP_REVIEW.html",
+        "r_parity_mount_id": "r-parity-brodalumab-pasi",
+        "rcs_kpi_id": "rcs-note-body",
+        "expected_badge": "deferred",
+        "allowed_amber_rows": [],
+        "deferral_must_contain": "deferred to engine v0.5",
+        # AMAGINE-specific check: the badge must explicitly surface the
+        # "engine-declined / R-fit" disagreement in the RCS rows. Without this,
+        # readers cannot tell whether the deferral is the SUSTAIN/SELECT
+        # case (both refused) or the AMAGINE case (engine refused, R fit).
+        "must_contain_phrases": [
+            "ENGINE-DECLINED / R-FIT",
+            "knots inside 140",  # part of "knots inside 140–210 mg gap"
+        ],
+    },
 ]
 
 
@@ -391,6 +435,28 @@ def main():
                         except AssertionError as e:
                             print(f"  ✗ {e}")
                             failed += 1
+
+                        # Test 5 (Round 3.9, AMAGINE-specific): if the flagship
+                        # specifies must_contain_phrases, each phrase must appear
+                        # in the rendered badge HTML. Round 3.9 uses this to
+                        # assert that the badge surfaces the "ENGINE-DECLINED /
+                        # R-FIT" disagreement explicitly (distinguishing it from
+                        # the SUSTAIN/SELECT case where both engines refused).
+                        # Flagships without this key skip the test silently
+                        # (back-compat with the 7 prior flagships).
+                        must_contain = flagship.get("must_contain_phrases")
+                        if must_contain:
+                            try:
+                                missing = [phrase for phrase in must_contain if phrase not in badge]
+                                assert not missing, (
+                                    f"{flagship['html']}: badge HTML missing required phrases "
+                                    f"{missing}. Badge HTML (first 2000 chars): {badge[:2000]}"
+                                )
+                                print(f"  ✓ badge contains required phrases: {must_contain}")
+                                passed += 1
+                            except AssertionError as e:
+                                print(f"  ✗ {e}")
+                                failed += 1
                     finally:
                         page.close()
             finally:


### PR DESCRIPTION
## Summary

Round 3.9 — 8th dose-response flagship, 3-trial AMAGINE brodalumab PASI 75 binary fixture. **First flagship in the pack where engine declines RCS and R fits anyway** (with degenerate knots), surfaced as a methodological teaching example.

- Engine `fitRCS` short-circuits to `fitLinear` with `layer='linear'`, `fallback='degenerate_to_linear'`, `rcs=null` because the cross-trial dose grid `{0, 140, 210}` mg has only 2 distinct positive doses (< K=3 required Harrell knot locations).
- R `dosresmeta` fits anyway — each trial has 2 non-reference arms (≥ K_p=2), so R's sparse-per-trial-arm guard does not fire — but its 3 percentile knots all land inside the 140–210 mg gap (`[157.5, 175, 192.5]`) with no interior data to support the within-range curvature. R reports `nonlinearity_wald_p = 1.64e-13`, but the test is on percentile placeholders, not data.
- Engine refusal is the methodologically conservative call; R's fit is technically valid arithmetic but interpretively dubious.

## What's in this commit

Most of the Round 3.9 work was shipped in the prior batch commit (`d78b4869a` "batch 17"). This commit finishes the loop:

1. **`BRODALUMAB_PSORIASIS_AMAGINE_DOSE_RESP_REVIEW.js`** — fixes a latent C-comment terminator bug on line 15 where `Q*/df` inside a `/* … */` header comment closed the comment prematurely, leaving JavaScript syntax garbage that triggered `Unexpected token ')'` on every page load. Rewritten as "Q-star over df is greater than 1" — same meaning, no `*/` collision. Playwright caught this when the new flagship entry was added to the smoke runner.
2. **`tests/test_flagship_playwright_smoke.py`** — adds the BRODALUMAB_PSORIASIS_AMAGINE smoke entry (5 new tests). `expected_badge='deferred'`, plus a new `must_contain_phrases` runner hook that asserts the badge HTML contains both `'ENGINE-DECLINED / R-FIT'` and `'knots inside 140'` — explicitly distinguishing this case from the SUSTAIN/SELECT pattern where both engine and R refused. The hook is generic; flagships without the key skip silently (back-compat).

The HTML body, JS analysis path, fixture, abstracts, R precompute, and field-paths.mjs contract entry (with new `rEngineDisagreesOnRcs: true` flag) were shipped in the prior commit and verified byte-identical here.

## Flagship structure (4 tabs)

1. **PASI 75 — Linear (k=3, HEADLINE)** — pooled log-RR per mg ≈ 0.00523/mg, RR at 210 mg ≈ 3.0; τ² ≈ 8.6e-7 (effectively zero, dose-response highly homogeneous across the 3 AMAGINE trials).
2. **RCS — engine refuses / R fits (methodological note)** — side-by-side panel showing verbatim engine output (rcs=null) and R output (knots inside 140–210 mg gap) with a "DECLINED / FIT BUT KNOTS UNINFORMATIVE" verdict table.
3. **PASI 75 — One-stage (R glmer pass-through)** — R lme4::glmer Poisson-with-offset; R reports `converged=false` (random_effects_var pinned at boundary, expected on a 3-trial strictly-monotonic pool).
4. **R-parity badge** — linear-slope row GREEN, linear-τ² row GREEN, 3 RCS rows ENGINE-DECLINED / R-FIT in a custom panel (NOT GREEN / AMBER / DEFERRED), one-stage row PASS-THROUGH.

## Citation erratum (AMAGINE-1)

PubMed MCP retrieval on 2026-05-14 confirmed the user-supplied citation `Papp KA et al. NEJM 2016;375(4):339-348` is incorrect. The actual AMAGINE-1 primary is `Papp KA et al. Br J Dermatol 2016;175(2):273-286` (PMID 26914406, DOI 10.1111/bjd.14493). AMAGINE-2 and AMAGINE-3 share one publication (Lebwohl 2015 NEJM, PMID 26422722). All corrections rendered in the trial inventory + abstract metadata.

## Test plan

- [x] `node tests/test_dose_response_engine.mjs` → **68 passed, 0 failed**
- [x] `node tests/test_flagship_field_paths.mjs` → **230 passed, 0 failed** (was 209; 21 new contract assertions for AMAGINE, including the knot-degeneracy invariant that every R knot lies strictly inside (min_positive_dose, max_positive_dose))
- [x] `python tests/test_flagship_playwright_smoke.py` → **33 passed, 0 failed** (was 28; 5 new smoke tests for AMAGINE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)