### PR TITLE
feat(dose-response): engine v0.5 — fitLOO leave-one-out sensitivity + SURPASS LOO tab demo

### DIFF
--- a/TIRZEPATIDE_T2D_SURPASS_DOSE_RESP_REVIEW.html
+++ b/TIRZEPATIDE_T2D_SURPASS_DOSE_RESP_REVIEW.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self'; object-src 'none'; base-uri 'none';">
 <title>Tirzepatide dose vs HbA1c in type 2 diabetes — pooled dose-response meta-analysis (5 SURPASS Phase 3 RCTs)</title>
-<meta name="description" content="Pooled within-drug dose-response re-analysis of 5 SURPASS Phase 3 RCTs of tirzepatide (5, 10, 15 mg once weekly) for HbA1c in adults with type 2 diabetes. Two-stage linear + RCS spline pool with full multivariate REML (engine v0.3.0) and R-precomputed one-stage validator. Headline: non-linearity Wald p = 0.035 — tirzepatide HbA1c response saturates after ~5 mg.">
+<meta name="description" content="Pooled within-drug dose-response re-analysis of 5 SURPASS Phase 3 RCTs of tirzepatide (5, 10, 15 mg once weekly) for HbA1c in adults with type 2 diabetes. Two-stage linear + RCS spline pool with full multivariate REML, leave-one-out (LOO) sensitivity (engine v0.5.0), and R-precomputed one-stage validator. Headline: non-linearity Wald p = 0.035 — tirzepatide HbA1c response saturates after ~5 mg; LOO sensitivity confirms the finding is robust to dropping any single trial except SURPASS-1 / SURPASS-5.">
 <style>
   body { font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; max-width: 1100px; margin: 1em auto; padding: 0 1em; color: #222; line-height: 1.5; }
   h1, h2, h3 { color: #1a3a5c; }
@@ -133,8 +133,9 @@
 <nav class="tab-nav" role="tablist" aria-label="Analysis tabs">
   <button id="tab-btn-hba1c-linear" data-tab="hba1c-linear" class="active" role="tab" aria-selected="true" aria-controls="tab-hba1c-linear" tabindex="0">1. HbA1c — Linear</button>
   <button id="tab-btn-hba1c-rcs" data-tab="hba1c-rcs" role="tab" aria-selected="false" aria-controls="tab-hba1c-rcs" tabindex="-1">2. HbA1c — RCS (headline)</button>
-  <button id="tab-btn-hba1c-os" data-tab="hba1c-os" role="tab" aria-selected="false" aria-controls="tab-hba1c-os" tabindex="-1">3. HbA1c — One-stage</button>
-  <button id="tab-btn-parity" data-tab="parity" role="tab" aria-selected="false" aria-controls="tab-parity" tabindex="-1">4. R-parity badge</button>
+  <button id="tab-btn-hba1c-loo" data-tab="hba1c-loo" role="tab" aria-selected="false" aria-controls="tab-hba1c-loo" tabindex="-1">3. LOO sensitivity (v0.5)</button>
+  <button id="tab-btn-hba1c-os" data-tab="hba1c-os" role="tab" aria-selected="false" aria-controls="tab-hba1c-os" tabindex="-1">4. HbA1c — One-stage</button>
+  <button id="tab-btn-parity" data-tab="parity" role="tab" aria-selected="false" aria-controls="tab-parity" tabindex="-1">5. R-parity badge</button>
 </nav>
 
 <section id="tab-hba1c-linear" class="tab-content active" role="tabpanel" tabindex="0" aria-labelledby="tab-btn-hba1c-linear">
@@ -152,6 +153,15 @@
   <div id="hba1c-rcs-tau2matrix"></div>
   <div id="hba1c-rcs-curve"></div>
   <div id="hba1c-rcs-forest"></div>
+</section>
+
+<section id="tab-hba1c-loo" class="tab-content" role="tabpanel" tabindex="0" aria-labelledby="tab-btn-hba1c-loo">
+  <h2 tabindex="-1">Leave-one-out (LOO) sensitivity — RCS layer (engine v0.5.0)</h2>
+  <div id="hba1c-loo-kpis" aria-live="polite" aria-atomic="true"></div>
+  <div id="hba1c-loo-headline"></div>
+  <div id="hba1c-loo-table"></div>
+  <div id="hba1c-loo-deltabar"></div>
+  <div id="hba1c-loo-methods"></div>
 </section>
 
 <section id="tab-hba1c-os" class="tab-content" role="tabpanel" tabindex="0" aria-labelledby="tab-btn-hba1c-os">

--- a/TIRZEPATIDE_T2D_SURPASS_DOSE_RESP_REVIEW.js
+++ b/TIRZEPATIDE_T2D_SURPASS_DOSE_RESP_REVIEW.js
@@ -177,6 +177,101 @@ window.addEventListener('DOMContentLoaded', function () {
   rfHtml += '</tbody></table></div>';
   document.getElementById('hba1c-rcs-forest').innerHTML = rfHtml;
 
+  // === Tab 3: LOO sensitivity (v0.5.0) ===
+  // Run leave-one-out RCS sensitivity over the 5-trial SURPASS pool.  fitLOO
+  // orchestrates fitRCS(subset) for each k-1=4 subset and computes per-trial
+  // delta vs the full pool.  The headline tirzepatide finding (nonlin Wald
+  // p = 0.0346) is the full-pool result; LOO surfaces which trial drives it
+  // most and whether dropping any one trial flips the significance verdict.
+  var hba1cLoo;
+  try {
+    hba1cLoo = DR._internal.fitLOO(hba1cTrials, { layer: 'rcs', knots: 3 });
+  } catch (e) {
+    console.error('[tirz] fitLOO failed:', e);
+    document.getElementById('hba1c-loo-kpis').innerHTML =
+      '<div class="rv-badge rv-badge-amber">LOO sensitivity unavailable: ' + escapeHtml(e.message) + '</div>';
+    hba1cLoo = null;
+  }
+  if (hba1cLoo) {
+    var fullNlP = hba1cLoo.full_pool.rcs ? hba1cLoo.full_pool.rcs.nonlinearity_wald_p : null;
+    // Max-swing nlP = LOO entry whose nlP differs most from the full-pool nlP.
+    var maxSwingP = null, maxSwingTrial = null, maxSwingDelta = 0;
+    hba1cLoo.loo.forEach(function (e) {
+      if (e.nonlinearity_wald_p != null && fullNlP != null) {
+        var d = Math.abs(e.nonlinearity_wald_p - fullNlP);
+        if (d > maxSwingDelta) {
+          maxSwingDelta = d;
+          maxSwingP = e.nonlinearity_wald_p;
+          maxSwingTrial = e.dropped_studlab;
+        }
+      }
+    });
+
+    document.getElementById('hba1c-loo-kpis').innerHTML =
+      '<div class="kpi-grid">' +
+      '<div class="kpi"><div class="kpi-label">Full-pool nonlin Wald p</div><div class="kpi-value">' + (fullNlP != null ? fullNlP.toFixed(4) : 'n/a') + '</div><div>headline finding (' + hba1cLoo.k_full + ' trials)</div></div>' +
+      '<div class="kpi"><div class="kpi-label">Max-swing nonlin p (LOO)</div><div class="kpi-value">' + (maxSwingP != null ? maxSwingP.toFixed(4) : 'n/a') + '</div><div>when dropping ' + (maxSwingTrial ? escapeHtml(String(maxSwingTrial).split(' ')[0]) : 'n/a') + '</div></div>' +
+      '<div class="kpi"><div class="kpi-label">Most influential trial</div><div class="kpi-value">' + (hba1cLoo.summary.most_influential_trial ? escapeHtml(String(hba1cLoo.summary.most_influential_trial).split(' ')[0]) : 'n/a') + '</div><div>max |Δslope| = ' + hba1cLoo.summary.max_abs_delta_slope.toFixed(5) + '</div></div>' +
+      '<div class="kpi"><div class="kpi-label">Significance flips</div><div class="kpi-value">' + (hba1cLoo.summary.any_significance_flip ? 'YES' : 'No') + '</div><div>any subset crosses p=0.05</div></div>' +
+      '<div class="kpi"><div class="kpi-label">Sign flips</div><div class="kpi-value">' + (hba1cLoo.summary.any_sign_flip ? 'YES' : 'No') + '</div><div>any subset flips slope CI sign</div></div>' +
+      '<div class="kpi"><div class="kpi-label">Degenerated subsets</div><div class="kpi-value">' + hba1cLoo.summary.n_degenerated + ' / ' + hba1cLoo.loo.length + '</div><div>RCS-fallback fires</div></div>' +
+      '</div>';
+
+    // Headline banner — what the LOO actually tells us about the v0.3.0 finding
+    var hlClass = hba1cLoo.summary.any_significance_flip ? 'rv-badge-amber' : 'rv-badge-green';
+    var hlText = hba1cLoo.summary.any_significance_flip
+      ? 'AMBER — at least one LOO subset crosses the p=0.05 boundary. The headline non-linearity finding is sensitive to the removal of the indicated trial(s); read the per-trial delta table below.'
+      : 'GREEN — no LOO subset flips the significance verdict; the headline non-linearity finding is robust to dropping any single trial.';
+    document.getElementById('hba1c-loo-headline').innerHTML =
+      '<div class="rv-badge ' + hlClass + '">' +
+      '<strong>LOO headline:</strong> Most influential trial: <em>' + escapeHtml(String(hba1cLoo.summary.most_influential_trial || 'n/a')) + '</em> (max |Δslope| = ' + hba1cLoo.summary.max_abs_delta_slope.toFixed(5) + '). ' + hlText + '<br>' +
+      '<span class="rv-disclosure">Each row below drops one SURPASS trial and re-fits the RCS pool on the remaining k-1=4 trials.  The full-pool RCS finding is non-linearity Wald p = ' + (fullNlP != null ? fullNlP.toFixed(4) : 'n/a') + ' (Tab 2 headline).  Engine: ' + escapeHtml(DR.engine_version) + '; LOO orchestrated by <code>DR._internal.fitLOO({layer:&#39;rcs&#39;, knots:3})</code>.</span></div>';
+
+    // Per-LOO table
+    var looTblHtml = '<h3>Per-trial leave-one-out re-fit (RCS layer)</h3>' +
+      '<div class="table-scroll"><table>' +
+      '<caption>Each row drops one SURPASS trial and re-fits the RCS pool on the remaining 4 trials.  Δslope = LOO pooled_slope_log − full-pool pooled_slope_log (negative = drop made the slope steeper).</caption>' +
+      '<thead><tr><th>Dropped trial</th><th>k<sub>loo</sub></th><th>Pooled slope (log)</th><th>95% CI</th><th>Nonlin p</th><th>Δslope</th><th>Sign flip</th><th>Sig flip</th><th>Degenerated</th></tr></thead><tbody>';
+    hba1cLoo.loo.forEach(function (e) {
+      var rowCls = e.significance_flip ? ' class="rv-row-amber"' : (e.sign_flip ? ' class="rv-row-amber"' : '');
+      looTblHtml += '<tr' + rowCls + '>' +
+        '<td>' + escapeHtml(String(e.dropped_studlab)) + '</td>' +
+        '<td>' + e.k_loo + '</td>' +
+        '<td>' + (Number.isFinite(e.pooled_slope_log) ? e.pooled_slope_log.toFixed(5) : 'n/a') + '</td>' +
+        '<td>' + (Number.isFinite(e.pooled_slope_log_ci_lo) ? e.pooled_slope_log_ci_lo.toFixed(5) : 'n/a') + ' to ' + (Number.isFinite(e.pooled_slope_log_ci_hi) ? e.pooled_slope_log_ci_hi.toFixed(5) : 'n/a') + '</td>' +
+        '<td>' + (e.nonlinearity_wald_p != null ? e.nonlinearity_wald_p.toFixed(4) : 'n/a') + '</td>' +
+        '<td>' + (Number.isFinite(e.delta_slope) ? e.delta_slope.toFixed(5) : 'n/a') + '</td>' +
+        '<td>' + (e.sign_flip ? 'YES' : 'no') + '</td>' +
+        '<td>' + (e.significance_flip ? 'YES' : 'no') + '</td>' +
+        '<td>' + (e.degenerated ? 'YES' : 'no') + '</td>' +
+        '</tr>';
+    });
+    looTblHtml += '</tbody></table></div>';
+    document.getElementById('hba1c-loo-table').innerHTML = looTblHtml;
+
+    // Δslope bar (text-bar visualisation: one row per LOO subset showing magnitude
+    // of Δslope as a unicode-block bar; avoids SVG so CSP stays strict).  Max bar
+    // width 40 chars; scale relative to max_abs_delta_slope.
+    var maxAbs = hba1cLoo.summary.max_abs_delta_slope || 1e-12;
+    var barHtml = '<h3>Δslope visual (per LOO subset)</h3>' +
+      '<div class="table-scroll"><table><caption>Bar chart: width proportional to |Δslope| relative to max swing across the 5 LOO subsets.  Direction marker: ▲ = LOO slope steeper than full pool (more negative); ▼ = LOO slope flatter than full pool.</caption>' +
+      '<thead><tr><th>Dropped trial</th><th>Δslope</th><th>Bar</th></tr></thead><tbody>';
+    hba1cLoo.loo.forEach(function (e) {
+      var d = e.delta_slope;
+      var w = Number.isFinite(d) ? Math.round(40 * Math.abs(d) / maxAbs) : 0;
+      var bar = (d < 0 ? '▲ ' : '▼ ') + '█'.repeat(Math.max(0, w));
+      barHtml += '<tr><td>' + escapeHtml(String(e.dropped_studlab)) + '</td>' +
+        '<td>' + (Number.isFinite(d) ? d.toFixed(5) : 'n/a') + '</td>' +
+        '<td><code style="font-family:monospace;">' + bar + '</code></td></tr>';
+    });
+    barHtml += '</tbody></table></div>';
+    document.getElementById('hba1c-loo-deltabar').innerHTML = barHtml;
+
+    document.getElementById('hba1c-loo-methods').innerHTML =
+      '<p><strong>Methodology:</strong> Leave-one-out (LOO) sensitivity is a standard meta-analysis robustness check: re-fit the pooled model k times, each time leaving out one trial, and inspect how the headline quantity moves.  Here the headline is the RCS non-linearity Wald p-value (full pool: ' + (fullNlP != null ? fullNlP.toFixed(4) : 'n/a') + ').  Engine v0.5.0 adds <code>DR._internal.fitLOO(trials, {layer, knots})</code> which orchestrates the k re-fits using the same fitRCS / fitLinear primitives that produce the full-pool fit; no new statistical machinery is introduced.  Per-trial delta = LOO_pooled_slope − full_pool_slope; sign_flip fires when the LOO CI-lower-bound sign differs from the full-pool sign; significance_flip fires when the LOO nonlin Wald p crosses 0.05.</p>' +
+      '<p style="margin-top:0.6em; font-size:0.92em; color:#444;"><strong>Interpretation for SURPASS:</strong> The full-pool finding (Wald p = ' + (fullNlP != null ? fullNlP.toFixed(4) : 'n/a') + ', headline of Tab 2) is sensitive to dropping either of the two placebo-anchored trials (SURPASS-1, SURPASS-5) — without one of those, the non-linearity p rises above 0.05 and the saturation finding is no longer significant at the 5% threshold.  The 3 active-comparator trials (SURPASS-2/-3/-4, where 5 mg serves as the reference per Option A) carry less weight for the non-linearity test because they contribute no information at the 0-to-5 mg interval where the saturation curve is steepest.  The LOO sensitivity is therefore a leading indicator that the full-pool finding is borderline-significant and would benefit from a future trial measuring sub-5 mg tirzepatide.  This LOO output is shown as a sensitivity check for the Tab 2 headline, not as a replacement primary analysis.</p>';
+  }
+
   // Render abstracts inline
   fetch('fixtures/dose_response/tirzepatide_t2d_surpass_abstracts.json').then(function (r) {
     if (!r.ok) throw new Error('abstracts JSON: HTTP ' + r.status);

--- a/rapidmeta-dose-response-engine-v1.js
+++ b/rapidmeta-dose-response-engine-v1.js
@@ -1,4 +1,4 @@
-/* rapidmeta-dose-response-engine-v1.js — v0.3.0 (2026-05-13)
+/* rapidmeta-dose-response-engine-v1.js — v0.5.0 (2026-05-14)
  *
  * Self-contained dose-response meta-analysis engine for RapidMeta.
  * Three layered fitters: two-stage Greenland-Longnecker linear (primary),
@@ -15,6 +15,13 @@
  *   - full multivariate REML for fitRCS via Nelder-Mead on Cholesky parameters
  *     of the τ² matrix; non-linearity Wald p matches R mixmeta within |Δ| < 0.1
  *   - Q-profile τ² CI for fitLinear (Viechtbauer 2007) returns finite bounds
+ *   - v0.4.0: k=1 single-trial branch (fitRCS) via within-trial t df + tau2=0
+ *   - v0.5.0: leave-one-out (LOO) sensitivity via _internal.fitLOO; orchestrates
+ *     fitLinear / fitRCS over each k-1 subset, handles k_full=2 (LOO drops to
+ *     single surviving trial) via the per-study slope cached by fitLinear and
+ *     the engine's existing k=1 fitRCS branch; demonstrated on the TIRZEPATIDE
+ *     SURPASS flagship (k=5; nonlin Wald p = 0.0346 full pool — most influential
+ *     LOO subset surfaced in the flagship's LOO sensitivity tab)
  *
  * Load as <script src="rapidmeta-dose-response-engine-v1.js" defer></script>;
  * exposes window.RapidMetaDoseResp.{ validate, fitLinear, fitRCS, fitOneStage,
@@ -27,7 +34,7 @@
   // Public methods are assigned to API.<name> immediately after each function
   // definition below. _internal helpers are similarly attached as defined.
   var API = {
-    engine_version: 'rapidmeta-dose-response-engine-v1@0.3.0',
+    engine_version: 'rapidmeta-dose-response-engine-v1@0.5.0',
     _internal: {},
   };
 
@@ -1583,6 +1590,208 @@
     return clone;
   }
   API.exportResults = exportResults;
+
+  // ===================================================================
+  // Section 4: fitLOO — leave-one-out sensitivity (v0.5.0)
+  // Orchestrates fitLinear / fitRCS over each k-1 subset and returns the
+  // per-trial delta vs the full pool. See engine header comment for
+  // semantics.  No new statistical machinery — only calls the existing
+  // layer fitters and assembles a per-trial delta record.
+  //
+  // k_full=2 special case:  fitLinear throws on k<2, and the LOO of a
+  // k=2 pool drops to k=1.  In that case we fall back to the surviving
+  // trial's own slope (from its per-study record, which fitLinear
+  // already computed for the full-pool fit) and mark degenerated=true.
+  // For RCS at k=1 the engine has a real single-trial path since v0.4
+  // (estimator wls_single_trial_rcs); we still mark degenerated when
+  // the LOO result's layer collapsed from rcs to linear (rcsKnots
+  // returned fewer than K distinct locations on the LOO subset).
+  // ===================================================================
+  function fitLOO(trials, opts) {
+    opts = opts || {};
+    var layer = opts.layer === 'linear' ? 'linear' : 'rcs';
+    var knots = (opts.knots != null) ? opts.knots : 3;
+    var fitOpts = {};
+    for (var k in opts) {
+      if (k !== 'layer' && Object.prototype.hasOwnProperty.call(opts, k)) {
+        fitOpts[k] = opts[k];
+      }
+    }
+
+    // Validate the full pool first; LOO is meaningless on an invalid pool.
+    var issues = validate(trials);
+    if (issues.length) throw new Error('fitLOO: ' + issues[0]);
+
+    var kFull = trials.length;
+    if (kFull < 2) {
+      // LOO over a k=1 pool would leave an empty subset; degenerate by spec.
+      // We still return a full_pool fit (RCS k=1 path) so downstream KPI
+      // code can read the headline without a null check.
+      var solo = (layer === 'rcs')
+        ? fitRCS(trials, fitOpts)
+        : (function () { throw new Error('fitLOO: cannot LOO a k=1 pool at layer=linear (fitLinear requires k>=2)'); })();
+      return {
+        layer: layer,
+        k_full: kFull,
+        full_pool: solo,
+        loo: [],
+        summary: {
+          max_abs_delta_slope: 0,
+          most_influential_trial: null,
+          any_sign_flip: false,
+          any_significance_flip: false,
+          n_degenerated: 0,
+          skipped_reason: 'k_full < 2 — cannot drop a trial'
+        }
+      };
+    }
+
+    // Full-pool fit at the chosen layer.
+    var fullPool;
+    if (layer === 'rcs') {
+      fullPool = fitRCS(trials, Object.assign({}, fitOpts, { knots: knots }));
+    } else {
+      fullPool = fitLinear(trials, fitOpts);
+    }
+    var fullSlope = fullPool.pooled_slope_log;
+    var fullNlP = (fullPool.rcs && fullPool.rcs.nonlinearity_wald_p != null) ? fullPool.rcs.nonlinearity_wald_p : null;
+    var fullCiLo = fullPool.pooled_slope_log_ci_lo;
+    var fullCiHi = fullPool.pooled_slope_log_ci_hi;
+    var fullSignLo = (fullCiLo == null || !isFinite(fullCiLo)) ? 0 : Math.sign(fullCiLo);
+    var fullNlSig = (fullNlP != null && isFinite(fullNlP)) ? (fullNlP < 0.05) : null;
+
+    // For the k_full=2 → k_loo=1 special case at the linear layer, we need a
+    // per-trial slope.  fitLinear populated full_pool.per_study with the
+    // GL-covariance-derived single-trial slope + SE; we lift it directly so
+    // the LOO "pool" is the surviving trial's own slope.
+    // For RCS k=2 → k=1, the engine's k=1 fitRCS branch is the real fit and
+    // we don't need this fallback — fitRCS(subset) returns the right thing.
+    var linearPerStudy = null;
+    if (layer === 'linear' && kFull === 2 && fullPool.per_study) {
+      linearPerStudy = fullPool.per_study;
+    }
+
+    var loo = [];
+    var maxAbsDelta = -Infinity;
+    var mostInflTrial = null;
+    var anySignFlip = false;
+    var anySigFlip = false;
+    var nDegen = 0;
+
+    for (var i = 0; i < kFull; i++) {
+      var dropped = trials[i];
+      var subset = trials.slice(0, i).concat(trials.slice(i + 1));
+      var sub, degenerated = false;
+
+      try {
+        if (layer === 'rcs') {
+          sub = fitRCS(subset, Object.assign({}, fitOpts, { knots: knots }));
+          // engine's RCS fallback flips layer to 'linear' when rcsKnots returns
+          // < K distinct knot locations on the LOO subset — that's degeneration
+          // for our purposes.
+          if (sub.layer === 'linear') degenerated = true;
+        } else {
+          // layer === 'linear'
+          if (subset.length < 2) {
+            // k_full=2 → k_loo=1: fall back to the surviving trial's per-study slope.
+            if (linearPerStudy == null || linearPerStudy.length !== 2) {
+              throw new Error('fitLOO: k_full=2 LOO requires fitLinear.per_study; got ' + (linearPerStudy && linearPerStudy.length));
+            }
+            // surviving idx is (1 - i); per_study is in trial order
+            var surv = linearPerStudy[1 - i];
+            var sloLo = surv.slope_log - 1.96 * surv.slope_log_se;
+            var sloHi = surv.slope_log + 1.96 * surv.slope_log_se;
+            sub = {
+              layer: 'linear',
+              k: 1,
+              pooled_slope_log: surv.slope_log,
+              pooled_slope_log_se: surv.slope_log_se,
+              pooled_slope_log_ci_lo: sloLo,
+              pooled_slope_log_ci_hi: sloHi,
+              hksj_mv: null,
+              tcrit: 1.96,
+              rcs: null,
+              _loo_single_trial_fallback: true
+            };
+            degenerated = true;
+          } else {
+            sub = fitLinear(subset, fitOpts);
+          }
+        }
+      } catch (e) {
+        // Even a fit failure produces a record so the caller can see which
+        // LOO subset broke and why.  No silent-failure sentinel: we surface
+        // the error message and mark degenerated.
+        sub = {
+          layer: layer,
+          k: subset.length,
+          pooled_slope_log: NaN,
+          pooled_slope_log_se: NaN,
+          pooled_slope_log_ci_lo: NaN,
+          pooled_slope_log_ci_hi: NaN,
+          hksj_mv: null,
+          tcrit: null,
+          rcs: null,
+          _loo_error: String(e && e.message || e)
+        };
+        degenerated = true;
+      }
+
+      var nlPSub = (sub.rcs && sub.rcs.nonlinearity_wald_p != null) ? sub.rcs.nonlinearity_wald_p : null;
+      var delta = isFinite(sub.pooled_slope_log) && isFinite(fullSlope)
+        ? (sub.pooled_slope_log - fullSlope) : NaN;
+      var subSignLo = (sub.pooled_slope_log_ci_lo == null || !isFinite(sub.pooled_slope_log_ci_lo))
+        ? 0 : Math.sign(sub.pooled_slope_log_ci_lo);
+      var signFlip = (subSignLo !== fullSignLo) && (fullSignLo !== 0) && (subSignLo !== 0);
+      var sigFlip = false;
+      if (fullNlSig !== null && nlPSub != null && isFinite(nlPSub)) {
+        var subSig = (nlPSub < 0.05);
+        sigFlip = (subSig !== fullNlSig);
+      }
+
+      if (degenerated) nDegen++;
+      if (signFlip) anySignFlip = true;
+      if (sigFlip) anySigFlip = true;
+      if (isFinite(delta) && Math.abs(delta) > maxAbsDelta) {
+        maxAbsDelta = Math.abs(delta);
+        mostInflTrial = dropped.studlab;
+      }
+
+      loo.push({
+        dropped_studlab: dropped.studlab,
+        dropped_idx: i,
+        k_loo: subset.length,
+        pooled_slope_log: sub.pooled_slope_log,
+        pooled_slope_log_se: sub.pooled_slope_log_se,
+        pooled_slope_log_ci_lo: sub.pooled_slope_log_ci_lo,
+        pooled_slope_log_ci_hi: sub.pooled_slope_log_ci_hi,
+        nonlinearity_wald_p: nlPSub,
+        hksj_mv: (sub.hksj_mv != null) ? sub.hksj_mv : null,
+        tcrit: (sub.tcrit != null) ? sub.tcrit : null,
+        delta_slope: delta,
+        sign_flip: signFlip,
+        significance_flip: sigFlip,
+        degenerated: degenerated
+      });
+    }
+
+    if (!isFinite(maxAbsDelta)) maxAbsDelta = 0;
+
+    return {
+      layer: layer,
+      k_full: kFull,
+      full_pool: fullPool,
+      loo: loo,
+      summary: {
+        max_abs_delta_slope: maxAbsDelta,
+        most_influential_trial: mostInflTrial,
+        any_sign_flip: anySignFlip,
+        any_significance_flip: anySigFlip,
+        n_degenerated: nDegen
+      }
+    };
+  }
+  API._internal.fitLOO = fitLOO;
 
   root.RapidMetaDoseResp = API;
   if (typeof module !== 'undefined' && module.exports) module.exports = API;

--- a/tests/test_dose_response_engine.mjs
+++ b/tests/test_dose_response_engine.mjs
@@ -909,6 +909,184 @@ test('fitRCS k=1 spline_coefs come from the single trial directly (covBeta = per
   }
 });
 
+// === v0.5.0 fitLOO leave-one-out sensitivity tests ===
+// fitLOO orchestrates fitLinear / fitRCS over each k-1 subset.  We test
+// orchestration, contract shape, and the k=2 single-trial fallback path.
+
+test('fitLOO is exposed on DR._internal and DR.engine_version is v0.5.0', () => {
+  assert.equal(typeof I.fitLOO, 'function', 'DR._internal.fitLOO must be a function');
+  assert.ok(/v?0\.5\.0$/.test(DR.engine_version), 'engine_version should end with v0.5.0; got: ' + DR.engine_version);
+});
+
+test('fitLOO on SURPASS (k=5) returns full_pool + 5 LOO entries (default RCS layer)', () => {
+  const fx = loadFx('tirzepatide_t2d_surpass.json');
+  const r = I.fitLOO(fx.trials, { layer: 'rcs', knots: 3 });
+  assert.equal(r.layer, 'rcs');
+  assert.equal(r.k_full, 5);
+  assert.equal(r.loo.length, 5, 'LOO should produce one entry per dropped trial');
+  // Every dropped_studlab is a real fixture studlab; k_loo === k_full - 1 throughout
+  const studlabs = new Set(fx.trials.map(t => t.studlab));
+  for (const e of r.loo) {
+    assert.ok(studlabs.has(e.dropped_studlab), 'LOO dropped_studlab must be a real studlab: ' + e.dropped_studlab);
+    assert.equal(e.k_loo, 4, 'k_loo at k_full=5 must be 4');
+    assert.ok(Number.isFinite(e.pooled_slope_log), 'pooled_slope_log finite');
+    assert.ok(Number.isFinite(e.pooled_slope_log_se), 'pooled_slope_log_se finite');
+  }
+});
+
+test('fitLOO SURPASS: summary.most_influential_trial is a real studlab from the fixture', () => {
+  const fx = loadFx('tirzepatide_t2d_surpass.json');
+  const r = I.fitLOO(fx.trials, { layer: 'rcs', knots: 3 });
+  const studlabs = new Set(fx.trials.map(t => t.studlab));
+  assert.ok(r.summary.most_influential_trial, 'most_influential_trial should be set when ≥1 finite delta');
+  assert.ok(studlabs.has(r.summary.most_influential_trial),
+    'most_influential_trial must be a real fixture studlab: ' + r.summary.most_influential_trial);
+  assert.ok(Number.isFinite(r.summary.max_abs_delta_slope) && r.summary.max_abs_delta_slope > 0,
+    'max_abs_delta_slope should be a positive finite number');
+});
+
+test('fitLOO SURPASS: delta_slope = entry.pooled_slope_log - full_pool.pooled_slope_log (1e-12)', () => {
+  const fx = loadFx('tirzepatide_t2d_surpass.json');
+  const r = I.fitLOO(fx.trials, { layer: 'rcs', knots: 3 });
+  const fullSlope = r.full_pool.pooled_slope_log;
+  for (const e of r.loo) {
+    const expected = e.pooled_slope_log - fullSlope;
+    near(e.delta_slope, expected, 1e-12, 'delta_slope for ' + e.dropped_studlab);
+  }
+});
+
+test('fitLOO SURPASS: sign_flip semantics — true iff CI_lo signs differ from full pool', () => {
+  const fx = loadFx('tirzepatide_t2d_surpass.json');
+  const r = I.fitLOO(fx.trials, { layer: 'rcs', knots: 3 });
+  const fullSignLo = Math.sign(r.full_pool.pooled_slope_log_ci_lo);
+  let anyComputed = false;
+  for (const e of r.loo) {
+    const subSignLo = Math.sign(e.pooled_slope_log_ci_lo);
+    const expectFlip = (subSignLo !== fullSignLo) && (fullSignLo !== 0) && (subSignLo !== 0);
+    assert.equal(e.sign_flip, expectFlip,
+      'sign_flip on ' + e.dropped_studlab + ': expected ' + expectFlip + ', got ' + e.sign_flip);
+    anyComputed = true;
+  }
+  assert.ok(anyComputed, 'should have iterated over ≥1 LOO entry');
+});
+
+test('fitLOO SURPASS: significance_flip surfaces when LOO drops nlP across 0.05 from full', () => {
+  const fx = loadFx('tirzepatide_t2d_surpass.json');
+  const r = I.fitLOO(fx.trials, { layer: 'rcs', knots: 3 });
+  // Full-pool nlP = 0.0346 (< 0.05).  Dropping SURPASS-1 (largest delta) raises
+  // nlP above 0.05 — this is the headline LOO finding for the flagship.
+  assert.ok(r.full_pool.rcs && r.full_pool.rcs.nonlinearity_wald_p < 0.05,
+    'precondition: full-pool nlP must be < 0.05 for sig_flip semantics to mean something');
+  // At least one LOO entry should flip significance (any_significance_flip=true).
+  assert.equal(r.summary.any_significance_flip, true,
+    'SURPASS has ≥1 LOO subset where nlP crosses 0.05 — at least one significance_flip=true expected');
+  let n = 0;
+  for (const e of r.loo) {
+    if (e.significance_flip) n++;
+  }
+  assert.ok(n >= 1, 'expected ≥1 entry with significance_flip=true; got ' + n);
+});
+
+test('fitLOO on GL-1992 (k=5) returns 5 LOO entries (no degeneration on canonical fixture)', () => {
+  const fx = loadFx('gl1992_alcohol_bc.json');
+  const r = I.fitLOO(fx.trials, { layer: 'rcs', knots: 3 });
+  assert.equal(r.k_full, 5);
+  assert.equal(r.loo.length, 5, 'one LOO entry per trial');
+  // GL-1992 has rich per-trial dose coverage; no LOO subset should degenerate
+  // (rcsKnots returns >=3 knots on every 4-trial subset).
+  assert.equal(r.summary.n_degenerated, 0, 'GL-1992 LOO subsets should all fit real RCS; got n_degenerated=' + r.summary.n_degenerated);
+});
+
+test('fitLOO opts.layer="linear" returns linear-layer full_pool + LOO entries', () => {
+  const fx = loadFx('gl1992_alcohol_bc.json');
+  const rLin = I.fitLOO(fx.trials, { layer: 'linear' });
+  assert.equal(rLin.layer, 'linear');
+  assert.equal(rLin.full_pool.layer, 'linear');
+  assert.equal(rLin.loo.length, 5);
+  for (const e of rLin.loo) {
+    // Linear-layer LOO has no nlP since fitLinear has no spline.
+    assert.equal(e.nonlinearity_wald_p, null,
+      'linear-layer LOO has no nonlinearity_wald_p; should be null for ' + e.dropped_studlab);
+    assert.ok(Number.isFinite(e.pooled_slope_log));
+  }
+  // any_significance_flip is false on linear layer (no nlP to flip)
+  assert.equal(rLin.summary.any_significance_flip, false,
+    'linear layer has no nlP → any_significance_flip must be false');
+});
+
+test('fitLOO opts.layer="rcs" produces RCS-layer summary with nlP fields populated', () => {
+  const fx = loadFx('tirzepatide_t2d_surpass.json');
+  const r = I.fitLOO(fx.trials, { layer: 'rcs', knots: 3 });
+  assert.equal(r.layer, 'rcs');
+  assert.equal(r.full_pool.layer, 'rcs');
+  for (const e of r.loo) {
+    if (!e.degenerated) {
+      assert.ok(Number.isFinite(e.nonlinearity_wald_p),
+        'rcs-layer non-degenerate LOO entry must have finite nonlinearity_wald_p; got ' + e.nonlinearity_wald_p + ' for ' + e.dropped_studlab);
+    }
+  }
+});
+
+test('fitLOO on SUSTAIN (k=6) handles RCS singular-design drops via degenerated flag', () => {
+  const fx = loadFx('semaglutide_t2d_sustain.json');
+  const r = I.fitLOO(fx.trials, { layer: 'rcs', knots: 3 });
+  assert.equal(r.k_full, 6);
+  assert.equal(r.loo.length, 6);
+  // SUSTAIN's engine RCS fit is k_RCS=2 (4 singular per-trial drops at the
+  // full pool); LOO over a subset that excludes one of the surviving trials
+  // may further reduce k_eff or trigger the engine's degenerate-to-linear
+  // fallback (rcs.layer collapsing to 'linear' on the subset).  The contract:
+  // every LOO entry has either layer='rcs' (degenerated=false) or
+  // layer='linear' (degenerated=true).  Verify no entry throws or returns NaN
+  // on the pooled slope, and at least one entry is degenerated (LOO of the
+  // already-sparse 6-trial pool exposes the engine's RCS-fallback branch).
+  for (const e of r.loo) {
+    assert.ok(Number.isFinite(e.pooled_slope_log),
+      'every LOO entry must produce a finite pooled_slope_log even after singular-design drops; got ' + e.pooled_slope_log + ' on ' + e.dropped_studlab);
+  }
+  // Sanity: SUSTAIN's sparse-arm pool is exactly the kind that exercises
+  // degenerated handling.  We don't require ≥1 degenerated (depends on
+  // exact fixture), but the engine MUST NOT throw — that's the contract.
+  assert.ok(r.summary.n_degenerated >= 0, 'n_degenerated must be a non-negative count');
+});
+
+test('fitLOO on SURMOUNT (k=2) drops to k=1 each time; engine handles both paths without throwing', () => {
+  const fx = loadFx('tirzepatide_obesity_surmount.json');
+  // RCS layer: at k_full=2 → k_loo=1.  SURMOUNT-1 alone has 4 arms (0/5/10/15)
+  // and fits the k=1 RCS branch with finite output; SURMOUNT-2 alone has 3
+  // arms {0,10,15} — only 2 distinct positive doses, fewer than K=3 knots →
+  // the engine's RCS-fallback to fitLinear fires, then fitLinear throws at
+  // k=1.  fitLOO's try/catch must surface that as a degenerated record (NaN
+  // slope, _loo_error populated) WITHOUT re-throwing.  Contract: every LOO
+  // entry must produce an output record, even on the degenerate sub-subset.
+  const rRcs = I.fitLOO(fx.trials, { layer: 'rcs', knots: 3 });
+  assert.equal(rRcs.k_full, 2);
+  assert.equal(rRcs.loo.length, 2);
+  let nFinite = 0, nDegen = 0;
+  for (const e of rRcs.loo) {
+    assert.equal(e.k_loo, 1, 'LOO of k=2 produces k_loo=1 subset');
+    if (Number.isFinite(e.pooled_slope_log)) nFinite++;
+    if (e.degenerated) nDegen++;
+  }
+  assert.ok(nFinite >= 1,
+    'at least one SURMOUNT LOO subset (the one keeping the 4-arm SURMOUNT-1) must produce a finite slope via the k=1 RCS branch');
+  assert.ok(nDegen >= 1,
+    'at least one SURMOUNT LOO subset (the one keeping the 3-arm SURMOUNT-2 with only 2 distinct doses) should degenerate');
+  // Linear layer at k_full=2: fitLinear throws on k<2, so fitLOO must use the
+  // surviving-trial per-study slope as the LOO "pool".  Each entry should be
+  // marked degenerated and have a finite slope from the surviving trial.
+  const rLin = I.fitLOO(fx.trials, { layer: 'linear' });
+  assert.equal(rLin.k_full, 2);
+  assert.equal(rLin.loo.length, 2);
+  for (const e of rLin.loo) {
+    assert.equal(e.k_loo, 1);
+    assert.ok(Number.isFinite(e.pooled_slope_log),
+      'k=2 linear-layer LOO must NOT throw; should use surviving trial slope from fitLinear.per_study. Got: ' + e.pooled_slope_log);
+    assert.equal(e.degenerated, true,
+      'k=2 → k=1 linear-layer LOO entry must be marked degenerated=true (single-trial fallback)');
+  }
+});
+
 let pass = 0, fail = 0;
 for (const { name, fn } of tests) {
   try { fn(); console.log(`✓ ${name}`); pass++; }

--- a/tests/test_flagship_field_paths.mjs
+++ b/tests/test_flagship_field_paths.mjs
@@ -730,6 +730,85 @@ for (const c of flagshipContracts) {
   console.log('');
 }
 
+// === v0.5.0 SURPASS LOO-tab contract (engine v0.5 demonstrator) ===
+// The SURPASS flagship reads DR._internal.fitLOO from the loaded engine and
+// renders a 5-tab page with the LOO sensitivity tab in slot 3.  These
+// assertions pin the engine-vs-flagship contract for the new tab so a
+// future engine refactor that renames or moves fitLOO breaks the test
+// (matching the pattern of the Round 2C field-path regression).
+console.log('SURPASS LOO-tab contract (engine v0.5.0 — DR._internal.fitLOO)');
+
+test('engine v0.5: DR.engine_version label is @0.5.0', () => {
+  assert.ok(/@0\.5\.0$/.test(DR.engine_version),
+    'engine_version label should end with @0.5.0; got ' + DR.engine_version);
+});
+
+test('engine v0.5: DR._internal.fitLOO is a function', () => {
+  assert.equal(typeof DR._internal.fitLOO, 'function',
+    'DR._internal.fitLOO must be a function on the engine v0.5.0 API');
+});
+
+test('SURPASS LOO: fitLOO(SURPASS, layer=rcs, knots=3) returns full_pool + 5 LOO entries', () => {
+  const fx = JSON.parse(fs.readFileSync(path.join(repoRoot, 'tests/dose_response_fixtures/tirzepatide_t2d_surpass.json'), 'utf8'));
+  const r = DR._internal.fitLOO(fx.trials, { layer: 'rcs', knots: 3 });
+  assert.equal(r.layer, 'rcs');
+  assert.equal(r.k_full, 5);
+  assert.equal(r.loo.length, 5);
+  assert.equal(r.full_pool.layer, 'rcs');
+  assert.ok(Number.isFinite(r.full_pool.rcs.nonlinearity_wald_p),
+    'full_pool.rcs.nonlinearity_wald_p must be finite (the SURPASS headline finding the LOO tab supports)');
+});
+
+test('SURPASS LOO-tab KPI fields populate without "n/a" — most_influential_trial, max_abs_delta_slope, full nlP', () => {
+  const fx = JSON.parse(fs.readFileSync(path.join(repoRoot, 'tests/dose_response_fixtures/tirzepatide_t2d_surpass.json'), 'utf8'));
+  const r = DR._internal.fitLOO(fx.trials, { layer: 'rcs', knots: 3 });
+  // KPI bar reads: full-pool nlP, most_influential_trial, max_abs_delta_slope.
+  // Each must produce a non-empty display string.
+  const fullNlP = r.full_pool.rcs.nonlinearity_wald_p;
+  assert.ok(Number.isFinite(fullNlP), 'full-pool nlP must be finite');
+  assert.ok(/^\d+\.\d{4}$/.test(fullNlP.toFixed(4)), 'fullNlP.toFixed(4) display: ' + fullNlP.toFixed(4));
+
+  assert.ok(r.summary.most_influential_trial,
+    'summary.most_influential_trial must be set (non-null/empty) so the KPI does not display "n/a"');
+  assert.equal(typeof r.summary.most_influential_trial, 'string');
+
+  assert.ok(Number.isFinite(r.summary.max_abs_delta_slope),
+    'summary.max_abs_delta_slope must be finite (KPI displays via .toFixed(5))');
+  assert.ok(/^\d+\.\d{5}$/.test(r.summary.max_abs_delta_slope.toFixed(5)),
+    'max_abs_delta_slope.toFixed(5) display: ' + r.summary.max_abs_delta_slope.toFixed(5));
+
+  // any_significance_flip / any_sign_flip — booleans (KPI displays YES/No).
+  assert.equal(typeof r.summary.any_significance_flip, 'boolean');
+  assert.equal(typeof r.summary.any_sign_flip, 'boolean');
+  assert.equal(typeof r.summary.n_degenerated, 'number');
+});
+
+test('SURPASS LOO-tab per-row contract: every LOO entry has all displayed fields finite', () => {
+  const fx = JSON.parse(fs.readFileSync(path.join(repoRoot, 'tests/dose_response_fixtures/tirzepatide_t2d_surpass.json'), 'utf8'));
+  const r = DR._internal.fitLOO(fx.trials, { layer: 'rcs', knots: 3 });
+  // The flagship's LOO table renders one row per entry; each row reads:
+  // dropped_studlab, k_loo, pooled_slope_log, pooled_slope_log_ci_lo/hi,
+  // nonlinearity_wald_p, delta_slope, sign_flip, significance_flip, degenerated.
+  // The on-page render gates each numeric on Number.isFinite, so we only
+  // need the engine to populate the right shape (NOT to guarantee every
+  // value is finite on a hypothetical future degenerate subset).  But for
+  // the canonical SURPASS k=5 fixture, every numeric SHOULD be finite.
+  r.loo.forEach(e => {
+    assert.ok(typeof e.dropped_studlab === 'string' && e.dropped_studlab.length > 0);
+    assert.equal(e.k_loo, 4, 'SURPASS LOO k_loo === 4 for every entry (k_full=5)');
+    assert.ok(Number.isFinite(e.pooled_slope_log));
+    assert.ok(Number.isFinite(e.pooled_slope_log_se));
+    assert.ok(Number.isFinite(e.pooled_slope_log_ci_lo));
+    assert.ok(Number.isFinite(e.pooled_slope_log_ci_hi));
+    assert.ok(Number.isFinite(e.nonlinearity_wald_p),
+      'SURPASS canonical fixture: every LOO subset fits real RCS; nlP must be finite');
+    assert.ok(Number.isFinite(e.delta_slope));
+    assert.equal(typeof e.sign_flip, 'boolean');
+    assert.equal(typeof e.significance_flip, 'boolean');
+    assert.equal(typeof e.degenerated, 'boolean');
+  });
+});
+
 console.log('-'.repeat(60));
 console.log(passed + ' passed, ' + failed + ' failed');
 process.exit(failed === 0 ? 0 : 1);

--- a/tests/test_flagship_playwright_smoke.py
+++ b/tests/test_flagship_playwright_smoke.py
@@ -78,6 +78,19 @@ FLAGSHIPS = [
         "rcs_kpi_id": "hba1c-rcs-kpis",
         "expected_badge": "green",
         "allowed_amber_rows": [],
+        # v0.5.0: SURPASS gets the engine-v0.5 LOO sensitivity tab demonstrator.
+        # The new tab is in slot 3 (Tab 3 — between RCS headline and One-stage).
+        # We assert (a) the tab button is in the DOM, (b) the tab panel mount
+        # contains the LOO headline phrase "Most influential trial" + a non-empty
+        # studlab from the fixture, and (c) the KPI bar populates without "n/a".
+        "loo_tab_button_id": "tab-btn-hba1c-loo",
+        "loo_tab_panel_id": "tab-hba1c-loo",
+        "loo_kpis_id": "hba1c-loo-kpis",
+        "loo_headline_id": "hba1c-loo-headline",
+        "loo_must_contain_phrases": [
+            "Most influential trial",
+            "LOO sensitivity",
+        ],
     },
     {
         # Round 3.5 — intentional k=2 small-k stress test; linear_tau2 row is
@@ -511,12 +524,16 @@ def main():
                             print(f"  ✗ {e}")
                             failed += 1
 
-                        # Test 4: engine_version span has been populated and contains 0.3.0
+                        # Test 4: engine_version span has been populated and contains 0.5.0.
+                        # Engine v0.5.0 (this PR) bumps the version label; all 10 flagships
+                        # read DR.engine_version directly from the loaded engine, so every
+                        # flagship now renders v0.5.0 even though only SURPASS surfaces the
+                        # new LOO sensitivity tab.
                         try:
-                            assert "0.3.0" in engine_version, (
-                                f"engine_version span text {engine_version!r} does not contain '0.3.0'"
+                            assert "0.5.0" in engine_version, (
+                                f"engine_version span text {engine_version!r} does not contain '0.5.0'"
                             )
-                            print(f"  ✓ engine v0.3.0 label rendered: {engine_version!r}")
+                            print(f"  ✓ engine v0.5.0 label rendered: {engine_version!r}")
                             passed += 1
                         except AssertionError as e:
                             print(f"  ✗ {e}")
@@ -542,6 +559,51 @@ def main():
                                 passed += 1
                             except AssertionError as e:
                                 print(f"  ✗ {e}")
+                                failed += 1
+
+                        # Test 6 (v0.5.0): SURPASS LOO-tab smoke. Only SURPASS
+                        # currently surfaces the engine v0.5 LOO sensitivity
+                        # tab; flagships without the loo_tab_button_id key
+                        # skip silently. Assertions:
+                        #  - tab button exists in the DOM
+                        #  - tab panel mount contains the documented headline
+                        #    phrases (e.g. "Most influential trial")
+                        #  - LOO KPI mount contains no forbidden "n/a" patterns
+                        #    that would indicate a fitLOO contract bug
+                        loo_btn_id = flagship.get("loo_tab_button_id")
+                        if loo_btn_id:
+                            try:
+                                btn_count = page.locator(f"#{loo_btn_id}").count()
+                                assert btn_count == 1, (
+                                    f"LOO tab button #{loo_btn_id} not found in DOM (count={btn_count}). "
+                                    f"Engine v0.5.0 LOO sensitivity tab must be rendered."
+                                )
+                                panel_id = flagship.get("loo_tab_panel_id")
+                                panel_text = page.locator(f"#{panel_id}").text_content() or ""
+                                kpi_id = flagship.get("loo_kpis_id")
+                                kpi_text = page.locator(f"#{kpi_id}").text_content() or ""
+                                must_phrases = flagship.get("loo_must_contain_phrases", [])
+                                missing = [p for p in must_phrases if p not in panel_text]
+                                assert not missing, (
+                                    f"LOO tab panel #{panel_id} missing required phrases "
+                                    f"{missing}. Panel text (first 800 chars): {panel_text[:800]}"
+                                )
+                                # Forbidden "n/a" patterns: any KPI value displayed as
+                                # literal "n/a" would indicate a missing field.
+                                forbidden_loo = ["max |Δslope| = n/a", "= n/a", "NaN"]
+                                hits = [f for f in forbidden_loo if f in kpi_text]
+                                # Note "= n/a" is broad on purpose; the LOO KPI bar
+                                # has 6 KPIs and any of them showing "= n/a" is a
+                                # contract failure.  If this triggers on a benign
+                                # disclaimer in the future, narrow the substring.
+                                assert not hits, (
+                                    f"LOO KPI mount #{kpi_id} contains forbidden 'n/a' display(s): "
+                                    f"{hits}. KPI text: {kpi_text[:500]}"
+                                )
+                                print(f"  ✓ LOO sensitivity tab renders (engine v0.5.0 demonstrator)")
+                                passed += 1
+                            except AssertionError as e:
+                                print(f"  ✗ LOO sensitivity tab: {e}")
                                 failed += 1
                     finally:
                         page.close()


### PR DESCRIPTION
## Summary

- **Engine v0.5.0**: New helper `DR._internal.fitLOO(trials, opts)` orchestrates `fitLinear` / `fitRCS` over each k-1 LOO subset; returns per-trial deltas vs the full pool plus a summary block (`most_influential_trial`, `max_abs_delta_slope`, `any_sign_flip`, `any_significance_flip`, `n_degenerated`). No new statistical machinery — pure orchestration around the existing layer fitters.
- **SURPASS flagship demonstrator**: New "LOO sensitivity (v0.5)" tab in slot 3 (between RCS headline and One-stage). Renders KPI bar (full-pool nlP, max-swing nlP, most influential trial, sign/sig-flip flags, degenerated count), per-trial delta table, unicode delta-bar visualisation, and methodology paragraph.
- **Headline**: SURPASS full-pool nonlin Wald `p = 0.0346` is borderline-significant — dropping either of the two placebo-anchored trials (SURPASS-1 / SURPASS-5) raises `p` above 0.05, which the LOO tab now makes explicit. Most influential trial: SURPASS-1 (Rosenstock 2021, drug-naive); max |Δslope| = 0.02389.

## Key design choices

- **k_full=2 special case**: `fitLinear` throws on k<2, so the linear-layer LOO at k=2 uses the surviving trial's per-study slope (cached on `fitLinear`'s full-pool `per_study` record) with `degenerated=true`. RCS at k=1 uses the existing v0.4 single-trial branch.
- **Engine RCS-fallback on sparse subsets**: When `rcsKnots` returns fewer than K knots on a LOO subset (e.g. SURMOUNT-2 alone has only 2 distinct positive doses), the engine's degenerate-to-linear fallback fires. `fitLOO` surfaces this via `degenerated=true` rather than throwing.
- **Try/catch around every LOO fit**: A failing subset records `_loo_error` and NaN slope; it does not poison the whole sensitivity report.
- **Engine version label**: All 10 flagships read `DR.engine_version` from the loaded engine, so the `@0.5.0` label appears uniformly across the portfolio even though only SURPASS surfaces the LOO tab in this PR.

## Test plan

- [x] Engine unit tests: `node tests/test_dose_response_engine.mjs` — **79 passed** (68 baseline + 11 new fitLOO assertions)
- [x] Flagship field-path contract tests: `node tests/test_flagship_field_paths.mjs` — **289 passed** (284 baseline + 5 new SURPASS LOO-tab contract assertions)
- [x] Playwright smoke tests: `python tests/test_flagship_playwright_smoke.py` — **43 passed** (42 baseline + 1 SURPASS LOO-tab DOM render check; v0.3.0 → v0.5.0 version-label assertion update uniform across all 10 flagships)
- [x] Visual verification: rendered SURPASS LOO tab shows correct headline — full-pool nlP = 0.0346, max-swing nlP = 0.1480 (dropping SURPASS-5), most influential trial = SURPASS-1, 0/5 degenerated subsets, AMBER significance-flip banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)