### PR TITLE
feat(dose-response): engine v0.6 — fitLinear k=1 single-trial support

### DIFF
--- a/rapidmeta-dose-response-engine-v1.js
+++ b/rapidmeta-dose-response-engine-v1.js
@@ -1,4 +1,4 @@
-/* rapidmeta-dose-response-engine-v1.js — v0.5.0 (2026-05-14)
+/* rapidmeta-dose-response-engine-v1.js — v0.6.0 (2026-05-14)
  *
  * Self-contained dose-response meta-analysis engine for RapidMeta.
  * Three layered fitters: two-stage Greenland-Longnecker linear (primary),
@@ -22,6 +22,11 @@
  *     the engine's existing k=1 fitRCS branch; demonstrated on the TIRZEPATIDE
  *     SURPASS flagship (k=5; nonlin Wald p = 0.0346 full pool — most influential
  *     LOO subset surfaced in the flagship's LOO sensitivity tab)
+ *   - v0.6.0: fitLinear k=1 single-trial branch — closes the asymmetry with
+ *     fitRCS (v0.4). Returns the per-trial GL/WLS slope estimate with tau2=0,
+ *     Q=0, hksj_qstar=1, PI degenerated to CI, tcrit=qt(0.975, n_arms-2)
+ *     within-trial df. estimator='wls_single_trial_linear',
+ *     ci_method='t_within_trial'. fitLinear at k>=2 is byte-identical to v0.5.
  *
  * Load as <script src="rapidmeta-dose-response-engine-v1.js" defer></script>;
  * exposes window.RapidMetaDoseResp.{ validate, fitLinear, fitRCS, fitOneStage,
@@ -34,7 +39,7 @@
   // Public methods are assigned to API.<name> immediately after each function
   // definition below. _internal helpers are similarly attached as defined.
   var API = {
-    engine_version: 'rapidmeta-dose-response-engine-v1@0.5.0',
+    engine_version: 'rapidmeta-dose-response-engine-v1@0.6.0',
     _internal: {},
   };
 
@@ -1062,10 +1067,12 @@
     var issues = validate(trials);
     if (issues.length > 0) throw new Error('fitLinear: ' + issues[0]);
 
-  // I-1 fix: validate() is a data-shape checker, not a statistical-feasibility
-  // checker. k<2 produces NaN downstream (qt(0.975, 0) is undefined).
-  if (trials.length < 2) {
-    throw new Error('fitLinear: requires k >= 2 trials; got k=' + trials.length);
+  // I-1 / v0.6.0: validate() is a data-shape checker, not a statistical-feasibility
+  // checker. k<1 is impossible (no trials → no engine work); k=1 dispatches to the
+  // single-trial branch below (matches fitRCS v0.4.0 k=1 behaviour). k>=2 falls
+  // through to the canonical REML + HKSJ pool.
+  if (trials.length < 1) {
+    throw new Error('fitLinear: requires k >= 1 trial; got k=' + trials.length);
   }
 
     var alpha = opts.alpha || 0.05;
@@ -1137,6 +1144,52 @@
         slope_log_se: seBeta,
         n_arms: T.arms.length
       });
+    }
+
+    // v0.6.0: fitLinear k=1 single-trial branch.
+    // Mirror of fitRCS v0.4.0 k=1 logic. With only one trial there is no
+    // between-study τ² to estimate and Cochran Q is undefined; we surface the
+    // trial's own GL/WLS slope (already computed above in perStudy[0]) with a
+    // within-trial t-CI on df = n_arms - 2. PI degenerates to CI (no
+    // between-study spread). HKSJ inactive (qstar=1, adj=1); estimator and
+    // ci_method labels are distinct from the k>=2 REML+HKSJ path so downstream
+    // consumers can detect single-trial mode.
+    if (trials.length === 1) {
+      var ps = perStudy[0];
+      var single_slope = ps.slope_log;
+      var single_se = ps.slope_log_se;
+      var n_arms_single = ps.n_arms;
+      var df_within = Math.max(1, n_arms_single - 2);
+      var tcrit_single = df_within >= 1 ? qt(1 - (opts.alpha || 0.05) / 2, df_within) : 1.96;
+      var maxObsSingle = 0;
+      for (var ai_s = 0; ai_s < trials[0].arms.length; ai_s++) {
+        var arm_s = trials[0].arms[ai_s];
+        if (!arm_s.is_reference && isFinite(arm_s.dose) && arm_s.dose > maxObsSingle) maxObsSingle = arm_s.dose;
+      }
+      return {
+        layer: 'linear', k: 1,
+        pooled_slope_log: single_slope,
+        pooled_slope_log_se: single_se,
+        pooled_slope_log_ci_lo: single_slope - tcrit_single * single_se,
+        pooled_slope_log_ci_hi: single_slope + tcrit_single * single_se,
+        tau2: 0, tau2_lo: 0, tau2_hi: 0,
+        Q: 0, Q_df: 0, I2: 0, H2: 1,
+        // PI degenerates to CI at k=1 (no between-study spread defined)
+        pi_lo: single_slope - tcrit_single * single_se,
+        pi_hi: single_slope + tcrit_single * single_se,
+        pi_df: df_within,
+        hksj_adj: 1, hksj_qstar: 1,
+        per_study: perStudy,
+        max_observed_dose: maxObsSingle,
+        coverage_warning: true,
+        fallback: null,
+        estimator: 'wls_single_trial_linear',
+        ci_method: 't_within_trial',
+        converged: true,
+        iterations: null,
+        _fitInternal: null,
+        engine_version: API.engine_version,
+      };
     }
 
     var k = perStudy.length;

--- a/tests/test_dose_response_engine.mjs
+++ b/tests/test_dose_response_engine.mjs
@@ -163,10 +163,14 @@ test('fitLinear refuses fitting on single_arm fixture', () => {
   assert.throws(() => DR.fitLinear(fx.trials, {}), /single arm|< 2 arms|validate/i);
 });
 
-test('fitLinear throws on k=1 (single trial)', () => {
+test('fitLinear on k=1 (single trial) no longer throws (v0.6.0)', () => {
+  // v0.5.0 threw with "k >= 2 trials"; v0.6.0 dispatches to single-trial branch.
+  // Detailed contract assertions for the k=1 branch live in the v0.6.0 block below.
   const fx = loadFx('gl1992_alcohol_bc.json');
   const oneTrial = [fx.trials[0]];
-  assert.throws(() => DR.fitLinear(oneTrial, {}), /k >= 2|requires k/i);
+  const res = DR.fitLinear(oneTrial, {});
+  assert.equal(res.k, 1);
+  assert.ok(Number.isFinite(res.pooled_slope_log));
 });
 
 // === Task 12: rcsBasis (RCS truncated power basis) ===
@@ -913,9 +917,9 @@ test('fitRCS k=1 spline_coefs come from the single trial directly (covBeta = per
 // fitLOO orchestrates fitLinear / fitRCS over each k-1 subset.  We test
 // orchestration, contract shape, and the k=2 single-trial fallback path.
 
-test('fitLOO is exposed on DR._internal and DR.engine_version is v0.5.0', () => {
+test('fitLOO is exposed on DR._internal and DR.engine_version is v0.6.0', () => {
   assert.equal(typeof I.fitLOO, 'function', 'DR._internal.fitLOO must be a function');
-  assert.ok(/v?0\.5\.0$/.test(DR.engine_version), 'engine_version should end with v0.5.0; got: ' + DR.engine_version);
+  assert.ok(/v?0\.6\.0$/.test(DR.engine_version), 'engine_version should end with v0.6.0; got: ' + DR.engine_version);
 });
 
 test('fitLOO on SURPASS (k=5) returns full_pool + 5 LOO entries (default RCS layer)', () => {
@@ -1085,6 +1089,85 @@ test('fitLOO on SURMOUNT (k=2) drops to k=1 each time; engine handles both paths
     assert.equal(e.degenerated, true,
       'k=2 → k=1 linear-layer LOO entry must be marked degenerated=true (single-trial fallback)');
   }
+});
+
+// === v0.6.0 fitLinear k=1 single-trial path tests (mirror of fitRCS v0.4) ===
+// Closes the asymmetry from v0.4 where fitRCS got k=1 support but fitLinear
+// still threw. Re-uses the ARTS-DN-derived 8-arm fixture from the fitRCS k=1
+// tests above (makeArtsDnSingleTrial).
+
+test('fitLinear k=1 single-trial path does not throw and produces sensible output', () => {
+  const trials = makeArtsDnSingleTrial();
+  const lin = DR.fitLinear(trials, {});
+  assert.equal(lin.k, 1);
+  assert.ok(Number.isFinite(lin.pooled_slope_log));
+  assert.ok(Number.isFinite(lin.pooled_slope_log_se));
+  assert.ok(lin.pooled_slope_log_se > 0);
+  assert.ok(Number.isFinite(lin.pooled_slope_log_ci_lo));
+  assert.ok(Number.isFinite(lin.pooled_slope_log_ci_hi));
+  assert.ok(lin.pooled_slope_log_ci_lo < lin.pooled_slope_log_ci_hi);
+});
+
+test('fitLinear k=1 estimator label is wls_single_trial_linear (not reml_hksj)', () => {
+  const lin = DR.fitLinear(makeArtsDnSingleTrial(), {});
+  assert.equal(lin.estimator, 'wls_single_trial_linear');
+});
+
+test('fitLinear k=1 ci_method is t_within_trial', () => {
+  const lin = DR.fitLinear(makeArtsDnSingleTrial(), {});
+  assert.equal(lin.ci_method, 't_within_trial');
+});
+
+test('fitLinear k=1 tau2=0, Q=0, I2=0 (no between-study heterogeneity defined)', () => {
+  const lin = DR.fitLinear(makeArtsDnSingleTrial(), {});
+  assert.equal(lin.tau2, 0);
+  assert.equal(lin.tau2_lo, 0);
+  assert.equal(lin.tau2_hi, 0);
+  assert.equal(lin.Q, 0);
+  assert.equal(lin.Q_df, 0);
+  assert.equal(lin.I2, 0);
+  assert.equal(lin.H2, 1);
+});
+
+test('fitLinear k=1 hksj_qstar=1, hksj_adj=1 (no Q-floor activation)', () => {
+  const lin = DR.fitLinear(makeArtsDnSingleTrial(), {});
+  assert.equal(lin.hksj_qstar, 1);
+  assert.equal(lin.hksj_adj, 1);
+});
+
+test('fitLinear k=1 tcrit = qt(0.975, n_arms-2) within-trial df', () => {
+  const trials = makeArtsDnSingleTrial();
+  const lin = DR.fitLinear(trials, {});
+  // ARTS-DN fixture has 8 arms → df_within = 8 - 2 = 6.
+  // qt(0.975, 6) ≈ 2.4469.
+  // tcrit isn't surfaced directly on the return; reconstruct from CI half-width.
+  const ciHalf = lin.pooled_slope_log_ci_hi - lin.pooled_slope_log;
+  const tcrit_recovered = ciHalf / lin.pooled_slope_log_se;
+  const tcrit_expected = I.qt(0.975, 6);
+  near(tcrit_recovered, tcrit_expected, 1e-10, 'tcrit reconstructed from CI matches qt(0.975, 6)');
+  // Sanity: t > z=1.96 at small df, < ~4
+  assert.ok(tcrit_recovered > 1.96, 'within-trial t > z at small df');
+  assert.ok(tcrit_recovered < 4, 'tcrit modest at n_arms=8');
+});
+
+test('fitLinear k=1 PI degenerates to CI (pi_lo = ci_lo, pi_hi = ci_hi)', () => {
+  const lin = DR.fitLinear(makeArtsDnSingleTrial(), {});
+  near(lin.pi_lo, lin.pooled_slope_log_ci_lo, 1e-12, 'pi_lo == ci_lo at k=1');
+  near(lin.pi_hi, lin.pooled_slope_log_ci_hi, 1e-12, 'pi_hi == ci_hi at k=1');
+});
+
+test('fitLinear k>=2 fixture (SURPASS, k=5) unchanged: pooled_slope_log regression-pin from v0.5', () => {
+  // Regression pin: v0.5.0 baseline values captured BEFORE v0.6.0 engine edit.
+  // If this fails, the k>=2 fitLinear path was perturbed by the v0.6 k=1 branch
+  // (which should be impossible — the k=1 branch returns before the REML pool).
+  const fx = loadFx('tirzepatide_t2d_surpass.json');
+  const lin = DR.fitLinear(fx.trials, {});
+  assert.equal(lin.k, 5);
+  assert.equal(lin.estimator, 'reml_hksj');
+  near(lin.pooled_slope_log, -0.06882512687116353, 1e-12,
+    'SURPASS pooled_slope_log regression pin from v0.5 baseline');
+  near(lin.pooled_slope_log_se, 0.10285426601824053, 1e-12,
+    'SURPASS pooled_slope_log_se regression pin from v0.5 baseline');
 });
 
 let pass = 0, fail = 0;

--- a/tests/test_flagship_field_paths.mjs
+++ b/tests/test_flagship_field_paths.mjs
@@ -341,14 +341,21 @@ for (const c of flagshipContracts) {
   console.log('Fixture: ' + c.flagship + '  ←  ' + path.basename(c.fixture));
   const fx = JSON.parse(fs.readFileSync(path.join(repoRoot, c.fixture), 'utf8'));
   const rJson = JSON.parse(fs.readFileSync(path.join(repoRoot, c.rJson), 'utf8'));
-  // At k=1 (singleTrial), fitLinear throws — only fitRCS runs.
+  // v0.6.0: fitLinear at k=1 now dispatches to single-trial branch (was: throw).
+  // For c.singleTrial fixtures we run fitLinear and assert the single-trial
+  // estimator label; the standard k>=2 pooled-slope contract block below is
+  // skipped since the RCS layer carries the linear-basis summary for these
+  // flagships.
   let lin = null;
   if (!c.singleTrial) {
     lin = DR.fitLinear(fx.trials, {});
   } else {
-    // Confirm the engine actually rejects k=1 for fitLinear (regression-pin the contract).
-    test('fitLinear: throws at k=1 (k=1 fitLinear path intentionally rejected — RCS layer carries the linear-basis summary)', () => {
-      assert.throws(() => DR.fitLinear(fx.trials, {}), /k\s*>=?\s*2|k=1|requires k/i);
+    test('fitLinear: k=1 single-trial path produces wls_single_trial_linear estimator (v0.6.0)', () => {
+      const linK1 = DR.fitLinear(fx.trials, {});
+      assert.equal(linK1.k, 1);
+      assert.equal(linK1.estimator, 'wls_single_trial_linear');
+      assert.equal(linK1.ci_method, 't_within_trial');
+      assert.ok(Number.isFinite(linK1.pooled_slope_log));
     });
   }
   const rcs = DR.fitRCS(fx.trials, { knots: c.rcsKnots });
@@ -736,16 +743,16 @@ for (const c of flagshipContracts) {
 // assertions pin the engine-vs-flagship contract for the new tab so a
 // future engine refactor that renames or moves fitLOO breaks the test
 // (matching the pattern of the Round 2C field-path regression).
-console.log('SURPASS LOO-tab contract (engine v0.5.0 — DR._internal.fitLOO)');
+console.log('SURPASS LOO-tab contract (engine v0.6.0 — DR._internal.fitLOO)');
 
-test('engine v0.5: DR.engine_version label is @0.5.0', () => {
-  assert.ok(/@0\.5\.0$/.test(DR.engine_version),
-    'engine_version label should end with @0.5.0; got ' + DR.engine_version);
+test('engine v0.6: DR.engine_version label is @0.6.0', () => {
+  assert.ok(/@0\.6\.0$/.test(DR.engine_version),
+    'engine_version label should end with @0.6.0; got ' + DR.engine_version);
 });
 
-test('engine v0.5: DR._internal.fitLOO is a function', () => {
+test('engine v0.6: DR._internal.fitLOO is a function', () => {
   assert.equal(typeof DR._internal.fitLOO, 'function',
-    'DR._internal.fitLOO must be a function on the engine v0.5.0 API');
+    'DR._internal.fitLOO must be a function on the engine v0.6.0 API');
 });
 
 test('SURPASS LOO: fitLOO(SURPASS, layer=rcs, knots=3) returns full_pool + 5 LOO entries', () => {
@@ -876,7 +883,13 @@ const looRollout = [
     expectedKFull: 2,
     expectedKLoo: 1,
     everyNlPFinite: false,  // some LOO subsets are k=1 with sparse arms → degenerated, nlP=null
-    expectedMostInfluential: 'SURMOUNT-2',
+    // v0.6.0: most-influential flipped from SURMOUNT-2 to SURMOUNT-1. Cause:
+    // previously (v0.5) dropping SURMOUNT-1 yielded a k=1 subset whose RCS fit
+    // degenerated to fitLinear, which then threw on k<2, producing NaN delta
+    // (degenerated=true, abs_delta=∞ ignored, not counted). v0.6's fitLinear
+    // k=1 branch returns a finite slope for that subset, so the larger absolute
+    // delta (SURMOUNT-1 drop |Δ|=0.67 > SURMOUNT-2 drop |Δ|=0.49) wins.
+    expectedMostInfluential: 'SURMOUNT-1',
   },
   {
     name: 'FINERENONE_ARTS_DN (k=1, explanatory panel)',

--- a/tests/test_flagship_playwright_smoke.py
+++ b/tests/test_flagship_playwright_smoke.py
@@ -619,16 +619,16 @@ def main():
                             print(f"  ✗ {e}")
                             failed += 1
 
-                        # Test 4: engine_version span has been populated and contains 0.5.0.
-                        # Engine v0.5.0 (this PR) bumps the version label; all 10 flagships
-                        # read DR.engine_version directly from the loaded engine, so every
-                        # flagship now renders v0.5.0 even though only SURPASS surfaces the
-                        # new LOO sensitivity tab.
+                        # Test 4: engine_version span has been populated and contains 0.6.0.
+                        # Engine v0.6.0 (this PR) bumps the version label for the fitLinear
+                        # k=1 single-trial branch addition; all 10 flagships read
+                        # DR.engine_version directly from the loaded engine, so every
+                        # flagship now renders v0.6.0.
                         try:
-                            assert "0.5.0" in engine_version, (
-                                f"engine_version span text {engine_version!r} does not contain '0.5.0'"
+                            assert "0.6.0" in engine_version, (
+                                f"engine_version span text {engine_version!r} does not contain '0.6.0'"
                             )
-                            print(f"  ✓ engine v0.5.0 label rendered: {engine_version!r}")
+                            print(f"  ✓ engine v0.6.0 label rendered: {engine_version!r}")
                             passed += 1
                         except AssertionError as e:
                             print(f"  ✗ {e}")
@@ -671,7 +671,7 @@ def main():
                                 btn_count = page.locator(f"#{loo_btn_id}").count()
                                 assert btn_count == 1, (
                                     f"LOO tab button #{loo_btn_id} not found in DOM (count={btn_count}). "
-                                    f"Engine v0.5.0 LOO sensitivity tab must be rendered."
+                                    f"Engine v0.6.0 LOO sensitivity tab must be rendered."
                                 )
                                 panel_id = flagship.get("loo_tab_panel_id")
                                 panel_text = page.locator(f"#{panel_id}").text_content() or ""
@@ -699,7 +699,7 @@ def main():
                                     f"LOO KPI mount #{kpi_id} contains forbidden display(s): "
                                     f"{hits}. KPI text: {kpi_text[:500]}"
                                 )
-                                print(f"  ✓ LOO sensitivity tab renders (engine v0.5.0 demonstrator)")
+                                print(f"  ✓ LOO sensitivity tab renders (engine v0.6.0 demonstrator)")
                                 passed += 1
                             except AssertionError as e:
                                 print(f"  ✗ LOO sensitivity tab: {e}")


### PR DESCRIPTION
## Summary

- **Engine v0.6.0**: closes the asymmetry from v0.4 where `fitRCS` got k=1 single-trial support but `fitLinear` still threw on k<2. `fitLinear` now dispatches k=1 to a single-trial branch that uses the trial's own GL/WLS slope estimate (lifted from the existing `perStudy` build).
- Return shape mirrors `fitRCS` v0.4 k=1 conventions: `tau2=0`, `Q=0`, `I2=0`, `H2=1`, `hksj_qstar=1`, `hksj_adj=1`; PI degenerates to CI (no between-study spread); `estimator='wls_single_trial_linear'`, `ci_method='t_within_trial'`; `tcrit=qt(0.975, n_arms-2)` within-trial t-CI.
- `fitLinear` at k≥2 is byte-identical to v0.5 (regression-pinned on SURPASS to `pooled_slope_log = -0.06882512687116353` at 1e-12).
- Synthetic smoke (`DR.fitLinear(arts_dn.trials, {})`): no throw, `estimator='wls_single_trial_linear'`, `pooled_slope_log = -0.0238 ± 0.0038`.

## Behavior changes

The SURMOUNT (k=2) `fitLOO` test's `expectedMostInfluential` flipped from `SURMOUNT-2` to `SURMOUNT-1`. Cause: in v0.5 dropping SURMOUNT-1 yielded a k=1 subset whose RCS-fallback-to-linear threw, producing `NaN` delta_slope (degenerated=true, abs_delta=Inf ignored). v0.6 returns a finite slope; the larger |Δ|=0.67 (drop SURMOUNT-1) > 0.49 (drop SURMOUNT-2) wins. Comment in `test_flagship_field_paths.mjs` documents the cause.

## Files

- `rapidmeta-dose-response-engine-v1.js` — header bumped to v0.6.0, k=1 branch added in `fitLinear` (after `perStudy` build, before REML pool). k≥2 path untouched.
- `tests/test_dose_response_engine.mjs` — 79 → 87 (+8 v0.6 k=1 assertions incl. SURPASS regression-pin); engine_version assertion bumped to v0.6.0; the existing "k=1 throws" test inverted to "k=1 succeeds".
- `tests/test_flagship_field_paths.mjs` — 401/401. k=1 flagship contract now asserts `wls_single_trial_linear` estimator; SURMOUNT expectedMostInfluential updated with explanatory comment; engine_version label test bumped.
- `tests/test_flagship_playwright_smoke.py` — 52/52. engine_version span assertion bumped 0.5.0 → 0.6.0.

## Out of scope

- Flagship HTML headings retain "engine v0.5" copy (ARTS-DN flagship was shipped with that label and doesn't call `fitLinear` at all, so the v0.6 branch is dormant for shipped flagships per the spec).
- `fitOneStage` and `fitRCS` are unchanged.

## Test plan

- [x] `node tests/test_dose_response_engine.mjs` → **87 passed, 0 failed**
- [x] `node tests/test_flagship_field_paths.mjs` → **401 passed, 0 failed**
- [x] `python tests/test_flagship_playwright_smoke.py` → **52 passed, 0 failed**
- [x] Synthetic k=1 smoke on `finerenone_arts_dn.json` fixture → no throw, `estimator='wls_single_trial_linear'`

Engine label rendered in all 10 flagships: `rapidmeta-dose-response-engine-v1@0.6.0`.

Generated with Claude Code