### PR TITLE
feat(dose-response): engine v0.8 — one-stage hierarchical REML in pure JS (fitOneStage)

### DIFF
--- a/rapidmeta-dose-response-engine-v1.js
+++ b/rapidmeta-dose-response-engine-v1.js
@@ -1,9 +1,10 @@
-/* rapidmeta-dose-response-engine-v1.js — v0.7.0 (2026-05-14)
+/* rapidmeta-dose-response-engine-v1.js — v0.8.0 (2026-05-15)
  *
  * Self-contained dose-response meta-analysis engine for RapidMeta.
  * Three layered fitters: two-stage Greenland-Longnecker linear (primary),
- * two-stage GL + RCS (Harrell defaults), one-stage hierarchical (read from
- * R-precomputed JSON; no JS fitter for this layer).
+ * two-stage GL + RCS (Harrell defaults), one-stage hierarchical (pure-JS
+ * profiled-REML for the continuous random-intercept-only model; binary
+ * one-stage still reads R-precomputed JSON — glmer-Poisson deferred to v0.9).
  *
  * Validated by:
  *   - parity vs dosresmeta::dosresmeta() on the canonical GL-1992 alcohol-
@@ -37,6 +38,27 @@
  *     the fraction below 0.05. Demonstrated on the SUSTAIN flagship (I^2=97
  *     percent — analytical-vs-bootstrap comparison most informative there).
  *     fitLinear/fitRCS are byte-identical to v0.6 at all k.
+ *   - v0.8.0: fitOneStage gains a pure-JS profiled-REML fitter for the
+ *     CONTINUOUS random-intercept-only one-stage model
+ *     lmer(mean ~ dose_scaled + (1|studlab), weights=n/sd^2, REML). When
+ *     precomputedJson==null and the pool is continuous, the layer is fitted
+ *     in JS (estimator='js_reml_onestage') instead of returning null:
+ *     reparameterize by the variance ratio theta=sigma2_u/sigma2_e, profile
+ *     out the fixed effects (GLS) and sigma2_e analytically using a
+ *     Sherman-Morrison per-study block inverse (rank-1 random intercept +
+ *     diagonal IV weights), golden-section minimize the 1-D profiled-REML
+ *     deviance over theta>=0, snap to the singular boundary (theta=0,
+ *     converged:false to mirror lme4) when it dominates. Back-transform
+ *     coef_dose=beta_scaled/dose_scale_sd; random_effects_var=theta*sigma2_e
+ *     on the original response scale. Validated vs R/lme4 1.1.37 on the 6
+ *     fittable continuous flagships to |rel-delta|<1e-4 (coef), <1e-3 (se),
+ *     <5e-3 (re-var). ci_method stays 'z_1.96' (predict() one-stage
+ *     sentinel). Fails closed (no fabricated defaults) on k<2, missing
+ *     required arm fields, or binary input. Binary one-stage (glmer-Poisson)
+ *     is an explicit v0.9 deferral: binary + precomputedJson==null still
+ *     returns null (legacy contract). The R-read path (precomputedJson!=null)
+ *     and fitLinear/fitRCS/fitLOO/fitBootstrap are byte-identical to v0.7 at
+ *     all k.
  *
  * Load as <script src="rapidmeta-dose-response-engine-v1.js" defer></script>;
  * exposes window.RapidMetaDoseResp.{ validate, fitLinear, fitRCS, fitOneStage,
@@ -49,7 +71,7 @@
   // Public methods are assigned to API.<name> immediately after each function
   // definition below. _internal helpers are similarly attached as defined.
   var API = {
-    engine_version: 'rapidmeta-dose-response-engine-v1@0.7.0',
+    engine_version: 'rapidmeta-dose-response-engine-v1@0.8.0',
     _internal: {},
   };
 
@@ -1537,34 +1559,353 @@
   API.nonLinearityTest = nonLinearityTest;
 
   // ===================================================================
-  // Section 3b: fitOneStage(trials, opts, precomputedJson) — JSON reader (Task 15)
-  // One-stage hierarchical is NOT fitted in JS v0.1.  Pass precomputedJson=null
-  // to signal the caller must run R Round-1B.  Pass the JSON object from
-  // outputs/r_validation/doseresp/<REVIEW>.json to read R precomputed coefs.
+  // Section 3b: fitOneStage(trials, opts, precomputedJson)
+  //   v0.1 (Task 15): JSON reader only — returned null when precomputedJson
+  //                    was null; echoed R coefs when supplied.
+  //   v0.8.0:          pure-JS profiled-REML fitter for the CONTINUOUS
+  //                    random-intercept-only one-stage model. Binary one-stage
+  //                    (glmer-Poisson) remains a JSON-reader / fail-closed
+  //                    path and is deferred to v0.9.
+  //
+  // Model (continuous), identical to scripts/r_validate_doseresp.R:
+  //   lmer(mean ~ dose_scaled + (1 | studlab), weights = n/sd², REML = TRUE)
+  //   dose_scaled = dose / dose_scale_sd, dose_scale_sd = sample SD (n-1
+  //   denominator) of all positive doses across all arms of all trials.
+  //   Per-arm weight w = n / sd²  (= 1 / Var(arm mean) = inverse of sd²/n).
+  //
+  // Profiled-REML solution (random-intercept-only is the one LMM case with a
+  // tractable 1-D profile):
+  //   Marginal per study j (n_j arms): V_j = σ²_u 1 1' + σ²_ε diag(1/w_i).
+  //   Reparameterize θ = σ²_u / σ²_ε.  Σ_j = θ 1 1' + diag(1/w_i) so
+  //   V_j = σ²_ε Σ_j.  Per block (Sherman–Morrison, rank-1 + diagonal):
+  //     Σ_j^{-1} = diag(w) − θ (w wᵀ) / (1 + θ Σ w)
+  //     log|Σ_j| = −Σ log(w_i) + log(1 + θ Σ w_i)
+  //   GLS β̂(θ) and profiled σ̂²_ε(θ)=r²/(N−p) are closed-form; the profiled
+  //   REML deviance is 1-D in θ:
+  //     d(θ) = log|Σ| + (N−p)[1+log(2π r²/(N−p))] + log|XᵀΣ⁻¹X|
+  //   Golden-section minimize over θ ≥ 0 (no new deps; reuses vendored
+  //   numerics).  Back-transform: coef_dose = β̂_scaled / dose_scale_sd;
+  //   se_dose = se_scaled / dose_scale_sd.  random_effects_var = σ̂²_u =
+  //   θ̂ · σ̂²_ε on the original response scale (response is NOT scaled — only
+  //   the dose covariate is — so this maps directly to lme4 VarCorr).
+  //
+  // ci_method stays 'z_1.96' (predict() at ~line 1599 special-cases the
+  // one-stage layer on this exact sentinel); the JS path keeps the same CI
+  // convention as the R-read path so downstream consumers are agnostic to
+  // whether coefficients came from R or JS.
+  //
+  // Fail-closed (no fabricated defaults — lessons.md substitution-on-missing):
+  //   - binary input + precomputedJson==null  -> return null (legacy contract;
+  //     glmer-Poisson is the v0.9 deferral)
+  //   - continuous k<2                         -> {fit_ok:false, error:...}
+  //     (between-study variance unidentifiable with one study; mirrors lme4
+  //     "grouping factors must have > 1 sampled level")
+  //   - missing/non-finite required arm field  -> {fit_ok:false, error:...}
   // ===================================================================
+
+  // Profiled-REML core for the continuous random-intercept-only one-stage
+  // model. `obs` = [{ s: studyIdx, y, x, w }], g = #studies, returns
+  // { fit_ok, coef_scaled, se_scaled, sigma2_u, converged } or
+  // { fit_ok:false, error }.
+  function _remlRandIntercept(obs, g) {
+    var N = obs.length, p = 2;  // intercept + dose_scaled
+    if (g < 2) {
+      return { fit_ok: false, error: 'one-stage REML requires >= 2 studies; ' +
+        'got ' + g + ' (between-study variance unidentifiable with a single study)' };
+    }
+    if (N - p < 1) {
+      return { fit_ok: false, error: 'one-stage REML requires N - p >= 1 residual df; got N=' +
+        N + ', p=' + p };
+    }
+    // Group observation indices by study.
+    var blocks = {};
+    for (var i = 0; i < N; i++) {
+      (blocks[obs[i].s] || (blocks[obs[i].s] = [])).push(obs[i]);
+    }
+    var blockList = Object.keys(blocks).map(function (k) { return blocks[k]; });
+
+    // Profiled-REML evaluation at variance ratio theta (= sigma2_u/sigma2_e).
+    function evalTheta(theta) {
+      var XtX = [[0, 0], [0, 0]], Xty = [0, 0], yty = 0, logdetS = 0;
+      for (var b = 0; b < blockList.length; b++) {
+        var blk = blockList[b];
+        var sw = 0;
+        for (var q = 0; q < blk.length; q++) sw += blk[q].w;
+        var denom = 1 + theta * sw;
+        // log|Sigma_j| = -sum log(w_i) + log(1 + theta * sum w_i)
+        for (var q2 = 0; q2 < blk.length; q2++) logdetS -= Math.log(blk[q2].w);
+        logdetS += Math.log(denom);
+        // Sigma_j^{-1} = diag(w) - theta (w wT)/denom  (Sherman-Morrison)
+        for (var ii = 0; ii < blk.length; ii++) {
+          var bi = blk[ii], xi0 = 1, xi1 = bi.x, yi = bi.y;
+          for (var jj = 0; jj < blk.length; jj++) {
+            var bj = blk[jj], xj0 = 1, xj1 = bj.x, yj = bj.y;
+            var sij = (ii === jj)
+              ? bi.w - theta * bi.w * bi.w / denom
+              : -theta * bi.w * bj.w / denom;
+            XtX[0][0] += xi0 * sij * xj0;
+            XtX[0][1] += xi0 * sij * xj1;
+            XtX[1][0] += xi1 * sij * xj0;
+            XtX[1][1] += xi1 * sij * xj1;
+            Xty[0] += xi0 * sij * yj;
+            Xty[1] += xi1 * sij * yj;
+            yty += yi * sij * yj;
+          }
+        }
+      }
+      var det = XtX[0][0] * XtX[1][1] - XtX[0][1] * XtX[1][0];
+      if (!(Math.abs(det) > 1e-300)) {
+        return { dev: Infinity };
+      }
+      var inv = [
+        [XtX[1][1] / det, -XtX[0][1] / det],
+        [-XtX[1][0] / det, XtX[0][0] / det],
+      ];
+      var beta0 = inv[0][0] * Xty[0] + inv[0][1] * Xty[1];
+      var beta1 = inv[1][0] * Xty[0] + inv[1][1] * Xty[1];
+      var r2 = yty - (beta0 * Xty[0] + beta1 * Xty[1]);
+      if (!(r2 > 0)) r2 = 1e-300;  // guard log of non-positive residual SS
+      var dev = logdetS + (N - p) * (1 + Math.log(2 * Math.PI * r2 / (N - p))) +
+        Math.log(det);
+      return { dev: dev, beta1: beta1, inv: inv, r2: r2 };
+    }
+
+    // Golden-section minimization of the profiled REML deviance over
+    // theta in [0, hi].  theta=0 is the pooled-WLS (sigma2_u -> 0) limit;
+    // lme4 reports converged:false on that boundary but still returns a
+    // well-defined beta-hat, so we mirror that semantic below.
+    var GR = (Math.sqrt(5) - 1) / 2;
+    var lo = 0, hi = 1e3;
+    // Expand hi until the deviance stops improving past it (bounded).
+    var fHi = evalTheta(hi).dev, fMid = evalTheta(hi / 2).dev;
+    for (var ex = 0; ex < 40 && fHi < fMid && hi < 1e12; ex++) {
+      hi *= 4; fMid = fHi; fHi = evalTheta(hi).dev;
+    }
+    var a = lo, c = hi;
+    var x1 = c - GR * (c - a), x2 = a + GR * (c - a);
+    var f1 = evalTheta(x1).dev, f2 = evalTheta(x2).dev;
+    for (var it = 0; it < 300; it++) {
+      if (f1 < f2) { c = x2; x2 = x1; f2 = f1; x1 = c - GR * (c - a); f1 = evalTheta(x1).dev; }
+      else { a = x1; x1 = x2; f1 = f2; x2 = a + GR * (c - a); f2 = evalTheta(x2).dev; }
+      if (Math.abs(c - a) < 1e-12) break;
+    }
+    var thetaHat = (a + c) / 2;
+    // Compare against the theta=0 boundary (singular / pooled-OLS fit). If
+    // the boundary deviance is within optimizer tolerance of (or below) the
+    // interior optimum, snap to 0 and flag converged:false (matches lme4's
+    // boundary (singular) fit reporting).
+    var f0 = evalTheta(0);
+    var fHat = evalTheta(thetaHat);
+    var atBoundary = false;
+    if (f0.dev <= fHat.dev + 1e-7 || thetaHat < 1e-8) {
+      thetaHat = 0; fHat = f0; atBoundary = true;
+    }
+    if (!isFinite(fHat.dev) || fHat.beta1 == null) {
+      return { fit_ok: false, error: 'profiled-REML optimization failed to produce a finite fit' };
+    }
+    var sigma2_e = fHat.r2 / (N - p);
+    var sigma2_u = thetaHat * sigma2_e;
+    var var_beta1 = sigma2_e * fHat.inv[1][1];
+    if (!(var_beta1 >= 0)) {
+      return { fit_ok: false, error: 'non-positive variance for the dose coefficient' };
+    }
+    return {
+      fit_ok: true,
+      coef_scaled: fHat.beta1,
+      se_scaled: Math.sqrt(var_beta1),
+      sigma2_u: sigma2_u,
+      // lme4 flags converged:false on the singular (boundary) fit even though
+      // the fixed effects are well-defined; mirror that exactly.
+      converged: !atBoundary,
+    };
+  }
+  API._internal.remlRandIntercept = _remlRandIntercept;
+
   function fitOneStage(trials, opts, precomputedJson) {
     // P2-9: opts is reserved for future use (currently ignored).
-    if (precomputedJson == null) return null;
-    var os = precomputedJson.one_stage || {};
+
+    // ---- Legacy R-read path (byte-identical to v0.7) ---------------------
+    if (precomputedJson != null) {
+      var os = precomputedJson.one_stage || {};
+      return {
+        layer: 'one_stage',
+        k: (trials && trials.length) || (precomputedJson.k || 0),
+        one_stage: {
+          coef_dose: os.coef_dose,
+          coef_dose_se: os.coef_dose_se,
+          coef_dose_ci_lo: os.coef_dose_ci_lo != null ? os.coef_dose_ci_lo : os.coef_dose - 1.96 * os.coef_dose_se,
+          coef_dose_ci_hi: os.coef_dose_ci_hi != null ? os.coef_dose_ci_hi : os.coef_dose + 1.96 * os.coef_dose_se,
+          converged: os.converged === true,
+          random_effects_var: os.random_effects_var,
+          fit_ok: os.fit_ok !== false,  // default true unless explicitly false in input
+          lme4_version: os.lme4_version,
+          dose_scale_sd: os.dose_scale_sd,
+          coef_dose_on_scaled: os.coef_dose_on_scaled,
+        },
+        pooled_slope_log: os.coef_dose,
+        pooled_slope_log_se: os.coef_dose_se,
+        fallback: null,
+        estimator: 'r_precomputed',
+        ci_method: 'z_1.96',
+        engine_version: API.engine_version,
+      };
+    }
+
+    // ---- v0.8 pure-JS path (precomputedJson == null) ---------------------
+    if (!Array.isArray(trials) || trials.length === 0) return null;
+
+    // Outcome-type probe — EXACTLY R's r_validate_doseresp.R convention:
+    //   is_continuous <- !is.null(trials[[1]]$arms[[1]]$mean) &&
+    //                    !is.null(trials[[1]]$arms[[1]]$sd)
+    // i.e. probe the FIRST arm of the FIRST trial (typically the reference
+    // arm, which carries mean+sd in continuous pools) by FIELD PRESENCE,
+    // not validity. A present-but-invalid sd on some OTHER arm is then
+    // caught by the strict per-arm fail-closed validation below — so a
+    // missing/0 sd fails closed instead of being silently misclassified as
+    // binary. This matches the R script's flatten+validate ordering.
+    var probeArms = trials[0].arms || [];
+    var probeArm = probeArms[0];
+    if (probeArm == null) return null;
+    // Continuous iff mean+sd fields are PRESENT (R's !is.null). Binary
+    // otherwise (events+n) — preserves the legacy null-on-binary contract;
+    // v0.9 will own the glmer-Poisson binary one-stage.
+    var isContinuous = (probeArm.mean != null) && (probeArm.sd != null);
+
+    // Binary one-stage = glmer-Poisson GLMM — explicit v0.9 deferral.
+    // Preserve the legacy null contract (caller must run R Round-1B); do NOT
+    // attempt a wrong Gaussian fit on log-RR contrasts.
+    if (!isContinuous) return null;
+
+    var k = trials.length;
+
+    function failClosed(msg) {
+      return {
+        layer: 'one_stage',
+        k: k,
+        one_stage: {
+          coef_dose: null,
+          coef_dose_se: null,
+          coef_dose_ci_lo: null,
+          coef_dose_ci_hi: null,
+          converged: false,
+          random_effects_var: null,
+          fit_ok: false,
+          error: msg,
+          lme4_version: null,
+          dose_scale_sd: null,
+          coef_dose_on_scaled: null,
+        },
+        pooled_slope_log: null,
+        pooled_slope_log_se: null,
+        fallback: null,
+        estimator: 'js_reml_onestage',
+        ci_method: 'z_1.96',
+        engine_version: API.engine_version,
+      };
+    }
+
+    if (k < 2) {
+      return failClosed('one-stage REML requires >= 2 studies; got k=' + k +
+        ' (between-study variance unidentifiable with a single study — ' +
+        'matches lme4 "grouping factors must have > 1 sampled level")');
+    }
+
+    // Collect all positive doses (every arm, every trial) for dose scaling.
+    // dose_scale_sd = sample SD (n-1 denominator) of positive doses — exactly
+    // R's sd(df$dose[df$dose > 0]).
+    var posDoses = [];
+    for (var t0 = 0; t0 < trials.length; t0++) {
+      var arms0 = trials[t0].arms || [];
+      for (var a0 = 0; a0 < arms0.length; a0++) {
+        var d0 = arms0[a0].dose;
+        if (!isFinite(d0)) {
+          return failClosed('trial "' + (trials[t0].studlab || ('#' + t0)) +
+            '": non-finite dose on an arm (required field)');
+        }
+        if (d0 > 0) posDoses.push(d0);
+      }
+    }
+    if (posDoses.length < 2) {
+      return failClosed('need >= 2 positive doses across all arms to compute ' +
+        'dose_scale_sd (sample SD); got ' + posDoses.length);
+    }
+    var meanD = 0;
+    for (var pd = 0; pd < posDoses.length; pd++) meanD += posDoses[pd];
+    meanD /= posDoses.length;
+    var ssD = 0;
+    for (var pd2 = 0; pd2 < posDoses.length; pd2++) {
+      var dv = posDoses[pd2] - meanD; ssD += dv * dv;
+    }
+    var doseScaleSd = Math.sqrt(ssD / (posDoses.length - 1));
+    if (!(doseScaleSd > 0)) {
+      return failClosed('dose_scale_sd is non-positive (all positive doses identical)');
+    }
+
+    // Flatten ALL arms (incl. reference) into model observations:
+    //   y = arm mean, x = dose / dose_scale_sd, w = n / sd² (= 1 / Var(mean)).
+    // Fail closed on any missing/invalid required field — never fabricate.
+    var obs = [];
+    for (var t = 0; t < trials.length; t++) {
+      var T = trials[t];
+      var lab = T.studlab || ('#' + t);
+      var arms = T.arms || [];
+      if (arms.length === 0) {
+        return failClosed('trial "' + lab + '": no arms');
+      }
+      for (var a = 0; a < arms.length; a++) {
+        var arm = arms[a];
+        if (!isFinite(arm.mean)) {
+          return failClosed('trial "' + lab + '" arm ' + a + ': missing/invalid required field "mean"');
+        }
+        if (!isFinite(arm.sd) || arm.sd <= 0) {
+          return failClosed('trial "' + lab + '" arm ' + a + ': missing/invalid required field "sd" (must be finite > 0)');
+        }
+        if (!isFinite(arm.n) || arm.n <= 0) {
+          return failClosed('trial "' + lab + '" arm ' + a + ': missing/invalid required field "n" (must be finite > 0)');
+        }
+        if (!isFinite(arm.dose)) {
+          return failClosed('trial "' + lab + '" arm ' + a + ': missing/invalid required field "dose"');
+        }
+        obs.push({
+          s: t,
+          y: arm.mean,
+          x: arm.dose / doseScaleSd,
+          w: arm.n / (arm.sd * arm.sd),
+        });
+      }
+    }
+
+    var fit = _remlRandIntercept(obs, trials.length);
+    if (!fit.fit_ok) {
+      return failClosed(fit.error || 'one-stage REML fit failed');
+    }
+
+    var coefScaled = fit.coef_scaled;
+    var seScaled = fit.se_scaled;
+    var coefDose = coefScaled / doseScaleSd;
+    var seDose = seScaled / doseScaleSd;
+    var ciLo = coefDose - 1.96 * seDose;
+    var ciHi = coefDose + 1.96 * seDose;
+
     return {
       layer: 'one_stage',
-      k: (trials && trials.length) || (precomputedJson.k || 0),
+      k: k,
       one_stage: {
-        coef_dose: os.coef_dose,
-        coef_dose_se: os.coef_dose_se,
-        coef_dose_ci_lo: os.coef_dose_ci_lo != null ? os.coef_dose_ci_lo : os.coef_dose - 1.96 * os.coef_dose_se,
-        coef_dose_ci_hi: os.coef_dose_ci_hi != null ? os.coef_dose_ci_hi : os.coef_dose + 1.96 * os.coef_dose_se,
-        converged: os.converged === true,
-        random_effects_var: os.random_effects_var,
-        fit_ok: os.fit_ok !== false,  // default true unless explicitly false in input
-        lme4_version: os.lme4_version,
-        dose_scale_sd: os.dose_scale_sd,
-        coef_dose_on_scaled: os.coef_dose_on_scaled,
+        coef_dose: coefDose,
+        coef_dose_se: seDose,
+        coef_dose_ci_lo: ciLo,
+        coef_dose_ci_hi: ciHi,
+        converged: fit.converged === true,
+        random_effects_var: fit.sigma2_u,
+        fit_ok: true,
+        lme4_version: null,           // not an lme4 fit — pure JS
+        dose_scale_sd: doseScaleSd,
+        coef_dose_on_scaled: coefScaled,
       },
-      pooled_slope_log: os.coef_dose,
-      pooled_slope_log_se: os.coef_dose_se,
+      pooled_slope_log: coefDose,
+      pooled_slope_log_se: seDose,
       fallback: null,
-      estimator: 'r_precomputed',
+      estimator: 'js_reml_onestage',
       ci_method: 'z_1.96',
       engine_version: API.engine_version,
     };

--- a/tests/test_dose_response_engine.mjs
+++ b/tests/test_dose_response_engine.mjs
@@ -1385,12 +1385,21 @@ test('fitBootstrap percentile CI semantics: bootstrap_ci_lo is the alpha/2 quant
 // methodological regression (wrong weights, wrong scaling, wrong REML
 // criterion) is still caught while iterative-optimizer noise is tolerated.
 
+// R ground-truth blocks live in outputs/r_validation/doseresp/<name>.json
+// (git-tracked). The matching per-trial model INPUT is read from the
+// git-tracked tests/dose_response_fixtures/<name>.json (loadFx) — NOT from
+// outputs/r_validation/doseresp/<name>.input.json, which is .gitignore'd
+// "plumbing" (.gitignore line 47: outputs/r_validation/**/*.input.json) and
+// therefore absent on CI runners. The two carry byte-identical trials/arms
+// data (verified: all 10 flagship fixtures MATCH), so loadFx is the correct
+// CI-safe source for the model input.
 const RVAL_DIR = join(__dirname, '..', 'outputs', 'r_validation', 'doseresp');
 function loadRval(name) {
   return JSON.parse(readFileSync(join(RVAL_DIR, name + '.json'), 'utf-8'));
 }
 function loadRvalInput(name) {
-  return JSON.parse(readFileSync(join(RVAL_DIR, name + '.input.json'), 'utf-8'));
+  // Per-trial input from the tracked test fixture (CI-safe), not .input.json.
+  return loadFx(name + '.json');
 }
 function relNear(actual, expected, relTol, absTol, label) {
   const denom = Math.abs(expected);

--- a/tests/test_dose_response_engine.mjs
+++ b/tests/test_dose_response_engine.mjs
@@ -298,7 +298,11 @@ test('fitRCS exposes internally-consistent Wald chi2/df/p triple (Round 2B fix-u
 
 // === Task 15: fitOneStage() ===
 
-test('fitOneStage returns null when precomputedJson is null', () => {
+test('fitOneStage returns null when precomputedJson is null (binary fixture — v0.9 deferral)', () => {
+  // gl1992_alcohol_bc is a BINARY fixture (events+n). The v0.8 pure-JS
+  // REML fitter only covers the continuous (Gaussian lmer) case; binary
+  // one-stage (glmer-Poisson) is deferred to v0.9, so the legacy
+  // null-on-binary contract is intentionally preserved here.
   const fx = loadFx('gl1992_alcohol_bc.json');
   const res = DR.fitOneStage(fx.trials, {}, null);
   assert.equal(res, null);
@@ -917,9 +921,9 @@ test('fitRCS k=1 spline_coefs come from the single trial directly (covBeta = per
 // fitLOO orchestrates fitLinear / fitRCS over each k-1 subset.  We test
 // orchestration, contract shape, and the k=2 single-trial fallback path.
 
-test('fitLOO is exposed on DR._internal and DR.engine_version is v0.7.0', () => {
+test('fitLOO is exposed on DR._internal and DR.engine_version is v0.8.0', () => {
   assert.equal(typeof I.fitLOO, 'function', 'DR._internal.fitLOO must be a function');
-  assert.ok(/v?0\.7\.0$/.test(DR.engine_version), 'engine_version should end with v0.7.0; got: ' + DR.engine_version);
+  assert.ok(/v?0\.8\.0$/.test(DR.engine_version), 'engine_version should end with v0.8.0; got: ' + DR.engine_version);
 });
 
 test('fitLOO on SURPASS (k=5) returns full_pool + 5 LOO entries (default RCS layer)', () => {
@@ -1345,6 +1349,240 @@ test('fitBootstrap percentile CI semantics: bootstrap_ci_lo is the alpha/2 quant
     'bootstrap_ci_hi must equal linear-interp percentile(sorted, 1-alpha/2)');
   near(r.bootstrap_median, expectedMed, 1e-12,
     'bootstrap_median must equal linear-interp percentile(sorted, 0.5)');
+});
+
+// ===================================================================
+// === v0.8.0: fitOneStage pure-JS one-stage hierarchical REML ===
+// ===================================================================
+// v0.8 replaces the JSON-reader-only fitOneStage with a real pure-JS
+// profiled-REML fitter for the CONTINUOUS random-intercept-only one-stage
+// model:  lmer(mean ~ dose_scaled + (1|studlab), weights = n/sd², REML=TRUE).
+//
+// Validation targets: the R/lme4 `one_stage` blocks cached under
+// outputs/r_validation/doseresp/<review>.json, with the per-trial model
+// input in the sibling <review>.input.json.  Of the 11 flagship fixtures,
+// 5 are BINARY (R uses glmer-Poisson — explicit v0.9 deferral, JS must
+// fail closed) and 6 are CONTINUOUS (R uses lmer-REML — the v0.8 must-ship).
+// One continuous fixture (finerenone_arts_dn, k=1) is itself a fail-closed
+// case in R (lme4: "grouping factors must have > 1 sampled level"); the JS
+// fitter must mirror that fail-closed outcome, not fabricate a value.
+//
+// TOLERANCE (documented per project norm — REML is iterative; lme4 uses
+// bobyqa, the JS engine uses golden-section on the profiled 1-D REML
+// criterion, so bit-identity is impossible and 1e-6 is too tight):
+//   - coef_dose          : relative tol 1e-4  (prototype worst |Δ_rel|≈4e-7,
+//                           ~3 orders of margin; still catches real drift)
+//   - coef_dose_se       : relative tol 1e-3  (second-order quantity derived
+//                           from the variance ratio θ; prototype ≈2e-6)
+//   - random_effects_var : relative tol 5e-3 OR abs tol 1e-5 (loosest — the
+//                           variance component is most sensitive to the θ
+//                           optimum, esp. near the singular-fit boundary
+//                           where lme4 reports converged:false)
+// Justification: the prototype profiled-REML solver (validated offline
+// against all 6 fittable continuous fixtures) hit |Δ_rel|≤4.4e-7 on
+// coef_dose, ≤2.4e-6 on se, and ≤3.9e-6 abs on re_var. The tolerances
+// above sit ~3 orders looser than observed agreement, so a real
+// methodological regression (wrong weights, wrong scaling, wrong REML
+// criterion) is still caught while iterative-optimizer noise is tolerated.
+
+const RVAL_DIR = join(__dirname, '..', 'outputs', 'r_validation', 'doseresp');
+function loadRval(name) {
+  return JSON.parse(readFileSync(join(RVAL_DIR, name + '.json'), 'utf-8'));
+}
+function loadRvalInput(name) {
+  return JSON.parse(readFileSync(join(RVAL_DIR, name + '.input.json'), 'utf-8'));
+}
+function relNear(actual, expected, relTol, absTol, label) {
+  const denom = Math.abs(expected);
+  const ok = denom > absTol
+    ? Math.abs(actual - expected) / denom <= relTol
+    : Math.abs(actual - expected) <= absTol;
+  assert.ok(ok, `${label}: actual=${actual} expected=${expected} relTol=${relTol} absTol=${absTol}`);
+}
+
+// The 6 continuous fixtures that lme4 fit successfully (excludes k=1
+// finerenone_arts_dn, which is a fail-closed case in R itself).
+const V08_CONT_OK = [
+  'erenumab_migraine_phase3',
+  'semaglutide_t2d_sustain',
+  'sglt2i_hba1c',
+  'tirzepatide_obesity_surmount',
+  'tirzepatide_t2d_surpass',
+  'upadacitinib_ra_select',
+];
+const V08_BINARY = [
+  'anifrolumab_sle_phase23',
+  'brodalumab_psoriasis_amagine',
+  'gl1992_alcohol_bc',
+  'sglt2i_hhf',
+];
+
+for (const fxName of V08_CONT_OK) {
+  test(`v0.8 fitOneStage pure-JS REML matches R/lme4 on ${fxName} (continuous)`, () => {
+    const inp = loadRvalInput(fxName);
+    const r = loadRval(fxName).one_stage;
+    assert.equal(r.fit_ok, true, `${fxName} R fixture should be fit_ok`);
+
+    const res = DR.fitOneStage(inp.trials, {}, null);
+    assert.ok(res != null, `${fxName}: continuous + precomputedJson=null must fit in JS, not return null`);
+    assert.equal(res.layer, 'one_stage');
+    assert.equal(res.estimator, 'js_reml_onestage',
+      `${fxName}: pure-JS path must label estimator js_reml_onestage`);
+    assert.equal(res.one_stage.fit_ok, true, `${fxName}: JS fit_ok`);
+
+    // dose_scale_sd is deterministic (sample SD of positive doses). The R
+    // fixture serializes it at digits=8 (r_validate_doseresp.R Round 3.1),
+    // so the pin is 8-sig-fig-aware: relTol 1e-7 (NOT bit-identity — the JS
+    // value is full double precision; the fixture is the rounded one).
+    relNear(res.one_stage.dose_scale_sd, r.dose_scale_sd, 1e-7, 1e-12,
+      `${fxName} dose_scale_sd`);
+    relNear(res.one_stage.coef_dose_on_scaled, r.coef_dose_on_scaled, 1e-4, 1e-9,
+      `${fxName} coef_dose_on_scaled`);
+    relNear(res.one_stage.coef_dose, r.coef_dose, 1e-4, 1e-9,
+      `${fxName} coef_dose`);
+    relNear(res.one_stage.coef_dose_se, r.coef_dose_se, 1e-3, 1e-9,
+      `${fxName} coef_dose_se`);
+    relNear(res.one_stage.random_effects_var, r.random_effects_var, 5e-3, 1e-5,
+      `${fxName} random_effects_var`);
+
+    // pooled_slope_log mirrors coef_dose for back-compat with predict()/forest().
+    near(res.pooled_slope_log, res.one_stage.coef_dose, 1e-12,
+      `${fxName} pooled_slope_log echoes coef_dose`);
+    near(res.pooled_slope_log_se, res.one_stage.coef_dose_se, 1e-12,
+      `${fxName} pooled_slope_log_se echoes coef_dose_se`);
+  });
+}
+
+test('v0.8 fitOneStage mirrors lme4 converged flag on singular-fit boundary fixtures', () => {
+  // semaglutide_t2d_sustain (k=6) and tirzepatide_t2d_surpass (k=5) both
+  // drive σ²_u → 0 (the pooled-OLS limit). lme4 reports converged:false
+  // (boundary / singular fit) while still returning usable fixed effects
+  // with fit_ok:true. The JS fitter must reproduce that semantic: fit_ok
+  // true (β̂ is well-defined), converged false (variance on boundary).
+  for (const fxName of ['semaglutide_t2d_sustain', 'tirzepatide_t2d_surpass']) {
+    const inp = loadRvalInput(fxName);
+    const r = loadRval(fxName).one_stage;
+    assert.equal(r.fit_ok, true);
+    assert.equal(r.converged, false, `${fxName} R baseline is a boundary (converged:false) fit`);
+    const res = DR.fitOneStage(inp.trials, {}, null);
+    assert.equal(res.one_stage.fit_ok, true, `${fxName}: β̂ is well-defined → fit_ok true`);
+    assert.equal(res.one_stage.converged, false,
+      `${fxName}: σ²_u on boundary → JS must mirror lme4 converged:false`);
+    assert.ok(res.one_stage.random_effects_var >= 0 && res.one_stage.random_effects_var < 1e-3,
+      `${fxName}: re_var collapses to ~0 at the OLS limit; got ${res.one_stage.random_effects_var}`);
+  }
+});
+
+test('v0.8 fitOneStage k=2 continuous edge (tirzepatide_obesity_surmount)', () => {
+  // k=2 is the minimum k at which the random-intercept variance is
+  // identifiable (R/lme4 fit it: converged:true). Verify the JS fitter
+  // produces a finite, R-matching estimate at the k=2 boundary.
+  const fxName = 'tirzepatide_obesity_surmount';
+  const inp = loadRvalInput(fxName);
+  const r = loadRval(fxName).one_stage;
+  assert.equal(loadRval(fxName).k, 2);
+  assert.equal(r.fit_ok, true);
+  const res = DR.fitOneStage(inp.trials, {}, null);
+  assert.equal(res.one_stage.fit_ok, true);
+  relNear(res.one_stage.coef_dose, r.coef_dose, 1e-4, 1e-9, `${fxName} k=2 coef_dose`);
+  relNear(res.one_stage.coef_dose_se, r.coef_dose_se, 1e-3, 1e-9, `${fxName} k=2 se`);
+  relNear(res.one_stage.random_effects_var, r.random_effects_var, 5e-3, 1e-5,
+    `${fxName} k=2 re_var`);
+});
+
+test('v0.8 fitOneStage k=1 continuous fails closed (finerenone_arts_dn) — matches lme4', () => {
+  // finerenone_arts_dn is k=1 continuous. lme4 itself refuses
+  // ("grouping factors must have > 1 sampled level") because the
+  // between-study variance is unidentifiable with a single study.
+  // The JS fitter must NOT fabricate a value — it must fail closed with
+  // fit_ok:false and a clear error string, mirroring R.
+  const fxName = 'finerenone_arts_dn';
+  const inp = loadRvalInput(fxName);
+  const r = loadRval(fxName).one_stage;
+  assert.equal(loadRval(fxName).k, 1);
+  assert.equal(r.fit_ok, false, 'R baseline: lme4 fails closed for k=1');
+  const res = DR.fitOneStage(inp.trials, {}, null);
+  assert.ok(res != null, 'k=1 must return a structured fail-closed object, not null');
+  assert.equal(res.one_stage.fit_ok, false,
+    'k=1 continuous: JS must fail closed (single study → re-var unidentifiable)');
+  assert.ok(typeof res.one_stage.error === 'string' && res.one_stage.error.length > 0,
+    'fail-closed object must carry a non-empty error string');
+  assert.equal(res.one_stage.coef_dose, null,
+    'no fabricated coefficient on a fail-closed k=1 fit');
+});
+
+for (const fxName of V08_BINARY) {
+  test(`v0.8 fitOneStage returns null for BINARY fixture ${fxName} (glmer-Poisson deferred to v0.9)`, () => {
+    // Binary one-stage in R is glmer(events ~ dose_scaled + (1|studlab),
+    // offset=log(n), family=poisson) — a GLMM, explicitly deferred to v0.9.
+    // The pure-JS REML fitter only covers the Gaussian (continuous) case;
+    // for binary input + precomputedJson=null it must preserve the legacy
+    // null contract (fail closed — caller must run R Round-1B), NOT
+    // attempt a wrong Gaussian fit on log-RR contrasts.
+    const inp = loadRvalInput(fxName);
+    const res = DR.fitOneStage(inp.trials, {}, null);
+    assert.equal(res, null,
+      `${fxName}: binary + precomputedJson=null must still return null (glmer-Poisson is a v0.9 deferral)`);
+  });
+}
+
+test('v0.8 fitOneStage R-precomputed path is byte-identical to v0.7 (no silent change)', () => {
+  // Backward-compat: when precomputedJson IS supplied, the legacy reader
+  // path must be preserved exactly (estimator r_precomputed, ci_method
+  // z_1.96, same field shape) so existing review .js files that pass an
+  // R fixture see no value change across the v0.7 → v0.8 bump.
+  const synthetic = { one_stage: { coef_dose: 0.05, coef_dose_se: 0.01, converged: true, random_effects_var: 0.003 } };
+  const res = DR.fitOneStage([], {}, synthetic);
+  assert.equal(res.estimator, 'r_precomputed', 'legacy R-read path unchanged');
+  assert.equal(res.ci_method, 'z_1.96', 'legacy z=1.96 CI semantics preserved');
+  near(res.one_stage.coef_dose, 0.05, 1e-12, 'R coef passthrough unchanged');
+  near(res.one_stage.coef_dose_ci_lo, 0.05 - 1.96 * 0.01, 1e-12, 'R-derived CI lo unchanged');
+  near(res.one_stage.coef_dose_ci_hi, 0.05 + 1.96 * 0.01, 1e-12, 'R-derived CI hi unchanged');
+});
+
+test('v0.8 fitOneStage JS path CI uses z=1.96 consistent with the one-stage ci_method contract', () => {
+  // The one-stage layer's documented ci_method is z_1.96 (predict() at
+  // ~line 1599 special-cases result.ci_method === 'z_1.96' for the
+  // one-stage layer). The pure-JS path keeps this convention so predict()
+  // / downstream consumers behave identically whether the coefficients
+  // came from R or from JS. CI = coef ± 1.96 * se on the original scale.
+  const inp = loadRvalInput('sglt2i_hba1c');
+  const res = DR.fitOneStage(inp.trials, {}, null);
+  assert.equal(res.ci_method, 'z_1.96',
+    'JS one-stage must keep z_1.96 ci_method (predict() depends on this sentinel)');
+  near(res.one_stage.coef_dose_ci_lo,
+    res.one_stage.coef_dose - 1.96 * res.one_stage.coef_dose_se, 1e-12,
+    'JS CI lo = coef - 1.96*se');
+  near(res.one_stage.coef_dose_ci_hi,
+    res.one_stage.coef_dose + 1.96 * res.one_stage.coef_dose_se, 1e-12,
+    'JS CI hi = coef + 1.96*se');
+});
+
+test('v0.8 fitOneStage fails closed (does NOT fabricate) on missing required arm fields', () => {
+  // Silent-corruption guard (lessons.md substitution-on-missing-required):
+  // a continuous trial missing sd on a non-reference arm must fail closed,
+  // never default sd to 1.0 / 0 / "unknown".
+  const broken = [{
+    studlab: 'A', arms: [
+      { dose: 0, mean: -0.1, sd: 0.5, n: 50, is_reference: true },
+      { dose: 10, mean: -0.4, n: 50, is_reference: false }, // sd missing
+    ],
+  }, {
+    studlab: 'B', arms: [
+      { dose: 0, mean: -0.1, sd: 0.5, n: 50, is_reference: true },
+      { dose: 10, mean: -0.4, sd: 0.5, n: 50, is_reference: false },
+    ],
+  }];
+  const res = DR.fitOneStage(broken, {}, null);
+  assert.ok(res != null && res.one_stage.fit_ok === false,
+    'missing sd must fail closed (fit_ok:false), not fabricate a default');
+  assert.ok(/sd|mean|n|required|finite/i.test(res.one_stage.error || ''),
+    'error must name the missing/invalid field; got: ' + (res.one_stage.error || ''));
+});
+
+test('v0.8 engine_version label is @0.8.0 (header + constant bumped)', () => {
+  assert.ok(/@0\.8\.0$/.test(DR.engine_version),
+    'engine_version label should end with @0.8.0; got ' + DR.engine_version);
 });
 
 let pass = 0, fail = 0;

--- a/tests/test_flagship_field_paths.mjs
+++ b/tests/test_flagship_field_paths.mjs
@@ -743,16 +743,21 @@ for (const c of flagshipContracts) {
 // assertions pin the engine-vs-flagship contract for the new tab so a
 // future engine refactor that renames or moves fitLOO breaks the test
 // (matching the pattern of the Round 2C field-path regression).
-console.log('SURPASS LOO-tab contract (engine v0.7.0 — DR._internal.fitLOO; engine bumped from v0.6 by v0.7 fitBootstrap addition)');
+console.log('SURPASS LOO-tab contract (engine v0.8.0 — DR._internal.fitLOO; engine bumped from v0.7 by v0.8 pure-JS one-stage REML addition)');
 
-test('engine v0.7: DR.engine_version label is @0.7.0', () => {
-  assert.ok(/@0\.7\.0$/.test(DR.engine_version),
-    'engine_version label should end with @0.7.0; got ' + DR.engine_version);
+test('engine v0.8: DR.engine_version label is @0.8.0', () => {
+  assert.ok(/@0\.8\.0$/.test(DR.engine_version),
+    'engine_version label should end with @0.8.0; got ' + DR.engine_version);
 });
 
-test('engine v0.7: DR._internal.fitLOO is a function (preserved from v0.5)', () => {
+test('engine v0.8: DR._internal.fitLOO is a function (preserved from v0.5)', () => {
   assert.equal(typeof DR._internal.fitLOO, 'function',
-    'DR._internal.fitLOO must be a function on the engine v0.7.0 API');
+    'DR._internal.fitLOO must be a function on the engine v0.8.0 API');
+});
+
+test('engine v0.8: DR._internal.remlRandIntercept is a function (new pure-JS one-stage core)', () => {
+  assert.equal(typeof DR._internal.remlRandIntercept, 'function',
+    'DR._internal.remlRandIntercept must be exposed on the engine v0.8.0 API');
 });
 
 test('SURPASS LOO: fitLOO(SURPASS, layer=rcs, knots=3) returns full_pool + 5 LOO entries', () => {

--- a/tests/test_flagship_playwright_smoke.py
+++ b/tests/test_flagship_playwright_smoke.py
@@ -631,16 +631,16 @@ def main():
                             print(f"  ✗ {e}")
                             failed += 1
 
-                        # Test 4: engine_version span has been populated and contains 0.7.0.
-                        # Engine v0.7.0 (this PR) bumps the version label for the
-                        # fitBootstrap trial-bootstrap CI addition; all 10 flagships
-                        # read DR.engine_version directly from the loaded engine, so
-                        # every flagship now renders v0.7.0.
+                        # Test 4: engine_version span has been populated and contains 0.8.0.
+                        # Engine v0.8.0 (this PR) bumps the version label for the
+                        # pure-JS one-stage hierarchical REML addition (fitOneStage);
+                        # all 10 flagships read DR.engine_version directly from the
+                        # loaded engine, so every flagship now renders v0.8.0.
                         try:
-                            assert "0.7.0" in engine_version, (
-                                f"engine_version span text {engine_version!r} does not contain '0.7.0'"
+                            assert "0.8.0" in engine_version, (
+                                f"engine_version span text {engine_version!r} does not contain '0.8.0'"
                             )
-                            print(f"  ✓ engine v0.7.0 label rendered: {engine_version!r}")
+                            print(f"  ✓ engine v0.8.0 label rendered: {engine_version!r}")
                             passed += 1
                         except AssertionError as e:
                             print(f"  ✗ {e}")


### PR DESCRIPTION
## Summary

Final extension in the locked v0.5→v0.8 series. Replaces `fitOneStage`'s JSON-reader-only behaviour with a real **pure-JS profiled-REML fitter** for the continuous random-intercept-only one-stage model. Binary one-stage (glmer-Poisson GLMM) is an explicit **v0.9 deferral** — the 5 binary flagship fixtures keep the legacy R-read / null path.

## Model

Identical to `scripts/r_validate_doseresp.R` (continuous path):

```
lmer(mean ~ dose_scaled + (1 | studlab), weights = n/sd², REML = TRUE)
```

- `dose_scaled = dose / dose_scale_sd`, `dose_scale_sd = sample SD (n-1)` of all positive doses across all arms of all trials (exactly R's `sd(df$dose[df$dose > 0])`).
- Per-arm weight `w = n / sd²` (= inverse of `Var(arm mean) = sd²/n`).

## Parameterization & solution

Random-intercept-only is the one LMM case with a tractable 1-D profile:

1. Reparameterize by the variance ratio `θ = σ²_u / σ²_ε`. Per-study marginal block `V_j = σ²_u 1 1ᵀ + σ²_ε diag(1/wᵢ) = σ²_ε Σ_j`.
2. **Sherman–Morrison** per-block inverse (rank-1 random intercept + diagonal IV weights): `Σ_j⁻¹ = diag(w) − θ (w wᵀ)/(1 + θ Σw)`; `log|Σ_j| = −Σ log(wᵢ) + log(1 + θ Σwᵢ)`.
3. Profile out the fixed effects (GLS β̂) and `σ²_ε = r²/(N−p)` analytically; **golden-section** minimize the 1-D profiled-REML deviance `d(θ) = log|Σ| + (N−p)[1+log(2π r²/(N−p))] + log|XᵀΣ⁻¹X|` over `θ ≥ 0` (reuses vendored numerics — no new deps).
4. Snap to the singular boundary (`θ=0`, `converged:false`) when it dominates — mirrors lme4's boundary (singular) fit reporting.

## Scaling / back-transform convention

- `coef_dose = β̂_scaled / dose_scale_sd`; `coef_dose_se = se_scaled / dose_scale_sd`.
- `random_effects_var = θ̂ · σ̂²_ε` on the **original response scale** (the response `mean` is not scaled — only the dose covariate is — so this maps directly to lme4 `VarCorr`; verified against fixtures).
- `ci_method` stays **`z_1.96`** (`predict()` at ~line 1599 special-cases the one-stage layer on this exact sentinel). The JS path keeps the same CI convention as the R-read path so downstream consumers are agnostic to fit source. CI = `coef ± 1.96·se` on the original scale.

## Validation table — pure-JS vs R/lme4 1.1.37 (6 fittable continuous flagships)

| Fixture | k | conv | coef_dose JS vs R \|Δrel\| | coef_dose_se \|Δrel\| | re_var \|Δ\| |
|---|---|---|---|---|---|
| sglt2i_hba1c | 3 | true | 4.4e-7 | 2.4e-6 | 1.1e-9 abs |
| semaglutide_t2d_sustain | 6 | false (boundary) | 3.6e-9 | 3.6e-9 | 1.1e-11 abs |
| erenumab_migraine_phase3 | 3 | true | 1.5e-7 | 6.4e-7 | 1.5e-7 abs |
| tirzepatide_obesity_surmount | 2 | true | 4.0e-9 | 1.1e-8 | 3.9e-6 abs |
| tirzepatide_t2d_surpass | 5 | false (boundary) | 2.8e-8 | 1.3e-7 | 1.3e-11 abs |
| upadacitinib_ra_select | 4 | true | 1.0e-7 | 1.3e-7 | 1.3e-8 abs |

**Chosen tolerances (documented in-test):** `coef_dose` rel **1e-4**, `coef_dose_se` rel **1e-3**, `random_effects_var` rel **5e-3 / abs 1e-5**. Justification: REML is iterative (lme4 bobyqa vs JS golden-section) so bit-identity is impossible and 1e-6 is too tight; the prototype solver hit ≤4.4e-7 / ≤2.4e-6 / ≤3.9e-6 — the pins sit ~3 orders looser than observed agreement, so a real methodological regression (wrong weights, wrong scaling, wrong REML criterion) is still caught while iterative-optimizer noise is tolerated.

## Edge cases

- **k=1** (`finerenone_arts_dn`): between-study variance unidentifiable with one study. lme4 itself fails closed ("grouping factors must have > 1 sampled level"); JS mirrors this — `fit_ok:false` + error string, **no fabricated coefficient**.
- **k=2** (`tirzepatide_obesity_surmount`): minimum identifiable k — matches R.
- **σ²_u → 0** (SUSTAIN k=6, SURPASS k=5): pooled-WLS limit; JS reproduces lme4's `converged:false` boundary semantic with `fit_ok:true`.
- **Missing required arm field**: fails closed naming the field (no `sd=1.0`/`"unknown"` substitution).
- **Binary input + precomputed=null**: returns `null` (legacy contract; glmer-Poisson is the v0.9 deferral).

## Backward compatibility

- R-read path (`precomputedJson != null`) **byte-identical to v0.7** (`estimator:r_precomputed`, `ci_method:z_1.96`, same field shape).
- `fitLinear`/`fitRCS`/`fitLOO`/`fitBootstrap` **byte-identical to v0.7 at all k** — proven by a 40 (fn × fixture) output-equality sweep across all 10 flagship fixtures (only `engine_version` string differs, by design).
- Engine version bumped to `@0.8.0` (header + constant); v0.7.0 regression pins in both Node suites updated to `@0.8.0` (matches v0.6→v0.7 precedent).

## Tests

- Engine suite: **97 → 114 pass / 0 fail** (+17 v0.8 tests)
- Field-paths contract: **407 → 408 pass / 0 fail** (+1 `remlRandIntercept` exposure test)
- prediction 83/0, panel 15/0 — no regressions

## Methodological finding

On **SUSTAIN** (`semaglutide_t2d_sustain`, k=6, I²≈97%): the one-stage REML **shrinks the slope ~11% toward zero** (−0.838 vs two-stage `fitLinear` −0.942) and **tightens SE ~10×** (0.160 vs 1.650), flipping the conclusion from non-significant (two-stage CI `[−4.18, +2.29]` crosses 0) to significant (one-stage CI `[−1.15, −0.53]`). Mechanism: the two-stage GL contrast-level τ²=0.41 loads onto **study intercepts** in the one-stage model, leaving σ²_u→0 for the slope (matched R/lme4 to ~1e-9). Direction is not universal — erenumab (k=3, real τ²>0) shows the one-stage SE *larger* (ratio 1.32). Validates `advanced-stats.md`'s one-stage-vs-two-stage divergence note under high heterogeneity.

## v0.9 deferral

**Binary one-stage (glmer-Poisson GLMM)** — explicitly out of scope for v0.8. The 5 binary flagship fixtures remain on the R-read / null path; recorded in the engine header changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)