### PR TITLE
NMA engine: true REML tau2 (Fisher scoring) — closes 4/5 netmeta divergences

### DIFF
--- a/rapidmeta-nma-engine-v2.js
+++ b/rapidmeta-nma-engine-v2.js
@@ -259,37 +259,44 @@
       return Math.max(0, (Q_FE - df) / cConst);
     }
     function tau2_REML() {
-      // Start from DL, iterate Jackson-Riley profile
-      var tau2 = tau2_DL();
-      for (var iter=0; iter<50; iter++) {
-        var Winv = v.map(function(vi){ return 1/(vi+tau2); });
-        var BtWB = zeros(T-1,T-1);
-        for(var a=0;a<T-1;a++)for(var b=0;b<T-1;b++){ var s=0; for(var i=0;i<k;i++) s+=B[i][a]*Winv[i]*B[i][b]; BtWB[a][b]=s; }
-        var BtWBinv = inverse(BtWB);
-        var BtWy = new Array(T-1).fill(0);
-        for(var a2=0;a2<T-1;a2++){ var s2=0; for(var i2=0;i2<k;i2++) s2+=B[i2][a2]*Winv[i2]*y[i2]; BtWy[a2]=s2; }
-        var beta = matvec(BtWBinv, BtWy);
-        var Q=0, sumW=0;
-        for(var i3=0;i3<k;i3++){
-          var yhat=0; for(var a3=0;a3<T-1;a3++) yhat += B[i3][a3]*beta[a3];
-          Q += Winv[i3]*Math.pow(y[i3]-yhat,2);
-          sumW += Winv[i3];
+      // True REML via Fisher scoring (matches netmeta method.tau="REML"). The
+      // earlier Jackson/DL-moment fixed-point underestimated tau2 on
+      // heterogeneous networks. For the contrast model y = B*beta + e,
+      // e ~ N(0, diag(v_i + tau2)), with W = diag(w_i), w_i = 1/(v_i+tau2),
+      // A = B'WB, H = B A^{-1} B', the REML projection matrix is
+      //   P = W - W H W  (symmetric).
+      // dV/dtau2 = I, so the REML score and Fisher information are
+      //   dl/dtau2 = (y'PPy - tr(P)) / 2,   I(tau2) = tr(PP) / 2,
+      // giving the update  tau2 += (y'PPy - tr(P)) / tr(PP), clamped at 0.
+      var df = k - (T - 1);
+      if (df <= 0) return 0;
+      var tau2 = Math.max(0, tau2_DL());
+      for (var iter = 0; iter < 200; iter++) {
+        var w = v.map(function (vi) { return 1 / (vi + tau2); });
+        var A = zeros(T - 1, T - 1);
+        for (var a = 0; a < T - 1; a++) for (var b = 0; b < T - 1; b++) {
+          var s = 0; for (var i = 0; i < k; i++) s += B[i][a] * w[i] * B[i][b]; A[a][b] = s;
         }
-        // Hedges estimator on contrast residuals:
-        //   tau2_new = max(0, (Q − (k − (T−1))) / (Σw − tr(B'WBB'WB)^{-1} ..))
-        // Use DL-in-network update (Jackson 2014 approximation):
-        var df = k - (T-1);
-        if (df <= 0) return 0;
-        var cConst = 0;
-        // Hat matrix diag for network: h_i = Winv[i] * (B_i (B'WB)^-1 B_i')
-        for (var i4=0;i4<k;i4++){
-          var bi = B[i4];
-          var vh = 0;
-          for (var a4=0;a4<T-1;a4++) for(var b4=0;b4<T-1;b4++) vh += bi[a4]*BtWBinv[a4][b4]*bi[b4];
-          cConst += Winv[i4] * (1 - Winv[i4]*vh);
+        var Ainv = inverse(A);
+        // beta_hat (WLS) -> residuals -> Py = W*resid
+        var g = new Array(T - 1).fill(0);
+        for (var a2 = 0; a2 < T - 1; a2++) { var s2 = 0; for (var i2 = 0; i2 < k; i2++) s2 += B[i2][a2] * w[i2] * y[i2]; g[a2] = s2; }
+        var beta = matvec(Ainv, g);
+        var Py = new Array(k);
+        for (var i3 = 0; i3 < k; i3++) { var yh = 0; for (var a3 = 0; a3 < T - 1; a3++) yh += B[i3][a3] * beta[a3]; Py[i3] = w[i3] * (y[i3] - yh); }
+        // H_ij = B_i Ainv B_j' ; cache H rows as needed.
+        function Hval(ii, jj) { var bi = B[ii], bj = B[jj], hh = 0; for (var ah = 0; ah < T - 1; ah++) for (var bh = 0; bh < T - 1; bh++) hh += bi[ah] * Ainv[ah][bh] * bj[bh]; return hh; }
+        var yPPy = 0; for (var i4 = 0; i4 < k; i4++) yPPy += Py[i4] * Py[i4]; // (Py)'(Py) = y'PPy (P symmetric)
+        var trP = 0; for (var i5 = 0; i5 < k; i5++) trP += w[i5] - w[i5] * w[i5] * Hval(i5, i5);
+        var trPP = 0;
+        for (var i6 = 0; i6 < k; i6++) for (var j6 = 0; j6 < k; j6++) {
+          var Pij = (i6 === j6 ? w[i6] : 0) - w[i6] * w[j6] * Hval(i6, j6);
+          trPP += Pij * Pij;
         }
-        var tau2_new = cConst > 0 ? Math.max(0, (Q - df) / cConst) : 0;
-        if (Math.abs(tau2_new - tau2) < 1e-8) { tau2 = tau2_new; break; }
+        if (!(trPP > 0)) break;
+        var step = (yPPy - trP) / trPP;
+        var tau2_new = Math.max(0, tau2 + step);
+        if (Math.abs(tau2_new - tau2) < 1e-10) { tau2 = tau2_new; break; }
         tau2 = tau2_new;
       }
       return tau2;

--- a/tests/nma_parity.mjs
+++ b/tests/nma_parity.mjs
@@ -43,21 +43,17 @@ const TOL_CONTRAST = 5e-3;
 const TOL_TAU2     = 5e-3;
 const TOL_SUCRA    = 0.04;
 
-// Documented KNOWN divergences (characterization, not a free pass). The engine's
-// network tau2 is a Jackson-2014 profile-likelihood approximation, not full
-// REML; on heterogeneous networks it underestimates netmeta's REML tau2, and the
-// random-effects contrasts drift in proportion to that tau2 gap. These datasets
-// are recorded with their reason so the gate still catches REGRESSIONS (a new
-// divergence, or one of these getting worse) while not red-failing CI on the
-// documented approximation limit. Removing the engine's tau2 approximation
-// (matching netmeta REML) is the follow-up that would let these be gated; it
-// needs R/netmeta to iterate against. See VAL-6 / NMA tau2 note.
+// Documented KNOWN divergences (characterization, not a free pass). The gate
+// still catches REGRESSIONS (a new divergence, or one of these getting worse)
+// AND a stale entry that no longer diverges, so the list stays honest.
+//
+// History: the engine's network tau2 was a Jackson-2014 profile approximation
+// that underestimated netmeta's REML tau2 on heterogeneous networks, causing
+// contrast drift on 5 datasets. Replacing it with true REML Fisher-scoring
+// (rapidmeta-nma-engine-v2.js tau2_REML) closed 4 of those 5. The remaining one
+// is a genuine netmeta-side degeneracy, not an engine issue:
 const KNOWN_DIVERGENCE = {
-  'antiamyloid_ad_nma_netmeta': 'tau2 engine 0 vs netmeta 2.8e-2 (REML approx underestimate)',
-  'il_psoriasis_nma_netmeta': 'tau2 engine 1.2e-1 vs netmeta 2.1e-1; contrast drift <=0.15',
-  'incretins_t2d_nma_netmeta': 'tau2 engine 0 vs netmeta 9.7e-2; contrast drift <=0.26',
-  'incretins_t2d_nma_stratumA_netmeta': 'tau2 engine 1.1e-2 vs netmeta 2.4e-2; contrast drift <=8e-3',
-  'incretins_t2d_nma_stratumB_netmeta': 'netmeta tau2 is NaN (degenerate); engine returns 0',
+  'incretins_t2d_nma_stratumB_netmeta': 'netmeta tau2 is NaN (degenerate fit); engine returns a finite 0',
 };
 
 // --- minimal R-vector extraction ----------------------------------------


### PR DESCRIPTION
Closes the documented follow-up from PR #318. R 4.6.0 + `netmeta` are now installed, so the engine's τ² was fixed against a live netmeta oracle.

## The fix
The engine's network τ² was a Jackson/DL-moment fixed-point approximation that **underestimated** netmeta's REML τ² on heterogeneous networks (it returned 0 where netmeta gave 0.097), which drove the contrast drift the parity harness flagged on 5 datasets.

Replaced `tau2_REML` with proper **REML Fisher scoring** on the projection matrix. For `y = B·β + e`, `e ~ N(0, diag(v_i+τ²))`, `W = diag(1/(v_i+τ²))`, `A = B'WB`, `H = B A⁻¹ B'`, `P = W − W H W`:
```
dl/dτ² = (y'PPy − tr(P))/2,   I = tr(PP)/2   →   τ² += (y'PPy − tr(P)) / tr(PP)   (clamped ≥ 0)
```
This is the same restricted-likelihood equation netmeta solves with `method.tau="REML"`.

## Validated against a LIVE netmeta run (not just the stored JSON)
| dataset | engine REML τ² | netmeta REML τ² |
|---|---|---|
| incretins_t2d | 0.096746 | 0.096700 |
| il_psoriasis | 0.208912 | 0.208912 |
| antiamyloid_ad | 0.028297 | 0.028297 |

## Parity harness
Clean passes **17 → 21 of 22**. The 4 previously-documented τ² divergences are gone. `KNOWN_DIVERGENCE` now holds only `incretins_t2d_stratumB`, where **netmeta's own** τ² is NaN (degenerate fit) and the engine returns a finite 0 — a netmeta-side edge, not an engine issue.

## Tests
`tests/test_review_fixes.py` (27) + `tests/test_nma_parity.py` (1) → **28 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)