### PR TITLE
Source-disagreement triage report (review aid; finding: most are not errors)

### DIFF
--- a/outputs/source_disagreements.csv
+++ b/outputs/source_disagreements.csv
@@ -1,0 +1,85 @@
+cat,rel_pct,app,nct,est,app_val,app_lci,app_uci,src_val,src_lci,src_uci,src_origin,outcome_title
+SIGNFLIP,652,ALS_NEW_AGENTS_NMA,NCT03127514,MD,2.32,.16,4.48,-0.42,-0.812,-0.028,outcome_measurements_mean_arms,ALSFRS-R 24wk CENTAUR
+SIGNFLIP,294,OSTEOPOROSIS_BROAD_NMA,NCT01796301,MD,6.2,5.4,7,-3.2,-3.7544,-2.6456,outcome_measurements_mean_arms,Total-hip BMD STRUCTURE
+SIGNFLIP,246,CGRP_MIGRAINE_PREVENT,NCT02456740,MD,2.04,1.66,2.51,-1.4,-1.88,-0.92,outcome_analyses,≥50% reduction in monthly migraine days at month 4-6
+SIGNFLIP,229,CGRP_MIGRAINE_PREVENT,NCT02483585,MD,1.34,1.07,1.69,-1.04,-1.61,-0.47,outcome_analyses,≥50% reduction in MMD at month 3
+SIGNFLIP,210,MYASTHENIA_GRAVIS_BIOLOGICS,NCT04115293,MD,2.29,1.39,3.76,-2.09,-3.24,-0.95,outcome_analyses,MG-ADL change at week 12
+SIGNFLIP,154,MYASTHENIA_GRAVIS_BIOLOGICS,NCT04735432,MD,2.25,1.41,3.59,-4.2,-7.73,-0.66,outcome_analyses,Total IgG ≥75% reduction (NI vs IV)
+RECIPROCAL,35,ANTI_PD1_GASTRIC,NCT02370498,HR,0.82,.66,1.03,1.27,1.03,1.57,outcome_analyses,OS in 2L PD-L1 CPS ≥1
+RECIPROCAL,25,HYPOFRAC_BREAST_RT_NMA,NCT00118209,HR,1.16,.84,1.61,0.93,0.68,1.27,outcome_analyses,5y IBTR NSABP-B-39
+RECIPROCAL,8,ENDOMETRIAL_IO_PARP,NCT03884101,HR,0.93,.79,1.1,1.01,0.83,1.24,outcome_analyses,PFS in 1L (NEGATIVE primary)
+RECIPROCAL,8,SBRT_PROSTATE_LOCAL_NMA,NCT00033631,HR,0.92,.68,1.25,1.0,0.83,1.2,outcome_analyses,5-year DFS hypofx (RTOG-0415)
+RECIPROCAL,8,VITAMIN_D_FRACTURE_FALL,NCT01169259,HR,1.04,.94,1.16,0.96,0.88,1.06,outcome_analyses,"Invasive cancer (vit D vs placebo, primary)"
+EXTREME,6216,T1D_CLOSED_LOOP_NMA,NCT04420572,MD,12.0,9,15,0.19,-0.3064,0.6864,outcome_measurements_mean_arms,TIR change 13wk PEDAP very young
+EXTREME,283,ALS_NEW_AGENTS_NMA,NCT00330681,MD,2.49,.99,3.99,0.65,-1.6923,2.9923,outcome_measurements_mean_arms,ALSFRS-R 24wk MCI-186-19
+EXTREME,148,DUCHENNE_GENE_THERAPY,NCT05096221,MD,1.61,1.06,2.45,0.65,-0.431,1.731,outcome_measurements_mean_arms,NSAA change at 52 weeks
+EXTREME,125,PROSTATE_AR_NEXT_GEN,NCT01946204,HR,0.63,.52,.76,0.28,0.227,0.346,outcome_analyses,Overall survival in mHSPC
+EXTREME,110,ACALABRUTINIB_CLL,NCT02475681,HR,0.21,.14,.32,0.1,0.06,0.17,outcome_analyses,"Investigator-assessed progression-free survival (primary, acalabrutinib vs chlor"
+MODERATE,90,PNH_NEW_COMPLEMENT,NCT04558918,OR,33.87,2.13,539.4,338.25,25.07,4564.14,outcome_analyses,Hemoglobin response in C5-experienced PNH
+MODERATE,85,SEVERE_ASTHMA_BIOLOGICS,NCT01691508,OR,0.36,.16,.81,2.39,1.25,4.56,outcome_analyses,Median % reduction in OCS dose at week 24
+MODERATE,76,IL_PSORIASIS_NMA,NCT03410992,OR,871.9,117.5,6483,496.318,82.798,2975.086,outcome_analyses,PASI 90 at week 16 bimekizumab 320 mg Q4W vs placebo (OR; BE READY; Haldane-Ansc
+MODERATE,75,PNH_NEW_COMPLEMENT,NCT04469465,MD,6.2,2.66,14.46,24.44,16.9,31.99,outcome_analyses,Hemoglobin response with factor D adjunct
+MODERATE,71,CARDIAC_CONTRACTILITY_MOD_NMA,NCT01381172,MD,0.84,.32,1.36,0.49,-0.6304,1.6104,outcome_measurements_mean_arms,Peak VO2 FIX-HF-5C
+MODERATE,66,CRC_TARGETED_BROAD,NCT04008030,HR,0.21,.14,.32,0.62,0.48,0.81,outcome_analyses,PFS in 1L MSI-H mCRC
+MODERATE,65,HEAD_NECK_IO_BROAD,NCT04428333,HR,0.76,.57,1.01,2.16,0.2,23.87,outcome_analyses,EFS in adjuvant high-risk HNSCC
+MODERATE,64,PBC_NEW_AGENTS,NCT04526665,OR,13.49,3.42,53.16,37.562,7.641,302.247,outcome_analyses,Composite biochemical response at 52 weeks
+MODERATE,44,PROSTATE_PARP_HRR_BROAD,NCT02987543,HR,0.49,.38,.63,0.34,0.25,0.47,outcome_analyses,rPFS in HRR+ post-AR mCRPC
+MODERATE,42,ARPI_mHSPC,NCT01715285,HR,0.66,.56,.78,0.466,0.394,0.55,outcome_analyses,"Overall survival (primary, abiraterone+ADT vs placebo+ADT; LATITUDE is the origi"
+MODERATE,40,DIABETIC_MACULAR_EDEMA,NCT01627249,MD,2.1,.4,3.8,3.5,1.4,5.7,outcome_analyses,"BCVA letter change at 1y, aflibercept vs ranibizumab (overall)"
+MODERATE,36,ALOPECIA_JAKI,NCT03899259,OR,10.66,4.41,25.81,7.86,2.79,22.17,outcome_analyses,"SALT <=20 (primary, baricitinib 4 mg vs placebo, severe alopecia areata; BRAVE-A"
+MODERATE,34,ARPI_mHSPC,NCT02489318,HR,0.65,.53,.79,0.484,0.391,0.6,outcome_analyses,Overall survival (final 2021 JCO update)
+MODERATE,33,AML_TARGETED_NEW,NCT03173248,HR,0.44,.27,.73,0.33,0.16,0.69,outcome_analyses,EFS in newly-diagnosed IDH1+ AML
+MODERATE,32,PROSTATE_AR_NEXT_GEN,NCT01949337,HR,0.63,.53,.75,0.93,0.8,1.08,outcome_analyses,Overall survival in mCRPC chemo-naive
+MODERATE,31,OVARIAN_PARP,NCT02655016,HR,0.43,.31,.59,0.62,0.502,0.755,outcome_analyses,PFS in 1L HRD-positive subgroup
+MODERATE,30,PROSTATE_RADIOLIGAND_BROAD,NCT04647526,HR,0.5,.39,.65,0.71,0.55,0.92,outcome_analyses,rPFS in pre-chemo mCRPC
+MODERATE,28,ANTI_PD1_GASTRIC,NCT03189719,HR,0.73,.62,.86,0.57,0.43,0.75,outcome_analyses,OS in 1L esophageal/GEJ
+MODERATE,28,ELACESTRANT_BC,NCT03778931,HR,0.7,.55,.88,0.546,0.387,0.768,outcome_analyses,Investigator-assessed PFS in ITT (primary; HR vs IC endocrine)
+MODERATE,27,PROSTATE_PARP_HRR_BROAD,NCT03748641,HR,0.53,.36,.79,0.729,0.556,0.956,outcome_analyses,rPFS in HRR+ subgroup
+MODERATE,26,ANTI_PDL1_BLADDER,NCT02256436,HR,0.73,.59,.91,0.98,0.81,1.19,outcome_analyses,OS in 2L urothelial
+MODERATE,26,IO_CHEMO_NSCLC_1L,NCT02366143,HR,0.78,.64,.96,0.62,0.52,0.74,outcome_analyses,"Overall survival (primary in EGFR/ALK-WT ITT, ABCP vs BCP, HR)"
+MODERATE,25,CTEPH_NMA,NCT01416636,MD,31.0,8,54,41.6,17.0685,66.1315,outcome_measurements_mean_arms,6MWD treprostinil INHALE
+MILD,24,MASH_DRUGS,NCT03008070,RR,1.88,1.13,3.13,1.52,0.98,2.12,outcome_analyses,SAF-A score reduction at week 24
+MILD,24,OVARIAN_PARP,NCT03106987,HR,0.43,.31,.6,0.566,0.372,0.868,outcome_analyses,PFS on re-challenge with PARP
+MILD,23,ENDOMETRIAL_IO_PARP,NCT04269200,HR,0.55,.43,.69,0.71,0.57,0.89,outcome_analyses,PFS with durva+olaparib+chemo
+MILD,22,ADJUVANT_IO_PAN_TUMOR,NCT02486718,HR,0.66,.5,.88,0.848,0.71,1.013,outcome_analyses,DFS in stage II-IIIA PD-L1+ NSCLC
+MILD,22,PROSTATE_PARP_HRR_BROAD,NCT02975934,HR,0.61,.47,.8,0.5,0.36,0.69,outcome_analyses,rPFS in BRCA+ post-AR cohort
+MILD,20,HEAD_NECK_IO_BROAD,NCT02358031,HR,0.74,.62,.89,0.93,0.78,1.11,outcome_analyses,OS in 1L PD-L1 CPS ≥20
+MILD,19,CHECKPOINT_MELANOMA_1L,NCT01866319,HR,0.69,.52,.9,0.58,0.46,0.72,outcome_analyses,Overall survival (5y update)
+MILD,19,PD1_RCC_1L,NCT04338269,HR,0.83,.67,1.04,1.03,0.83,1.28,outcome_analyses,OS in advanced RCC (subcutaneous formulation)
+MILD,19,PROSTATE_RADIOLIGAND_BROAD,NCT01578239,HR,0.21,.13,.33,0.177,0.108,0.289,outcome_analyses,PFS in midgut NET
+MILD,18,SCLC_IO,NCT04026412,HR,0.78,.54,1.13,0.95,0.77,1.19,outcome_analyses,OS in 1L (small phase 2 ECOG)
+MILD,16,BLADDER_UROTHEL_FRONTLINE_IO_NMA,NCT02516241,HR,0.99,.83,1.18,0.85,0.688,1.063,outcome_analyses,OS DANUBE durva (NEGATIVE)
+MILD,16,CHECKPOINT_ESOPHAGEAL_SCC,NCT03143153,HR,0.74,.58,.96,0.64,0.46,0.9,outcome_analyses,OS in PD-L1 TPS ≥1% (1L)
+MILD,16,NSCLC_PD1_1L,NCT02220894,HR,0.81,.71,.93,0.7,0.58,0.86,outcome_analyses,OS in PD-L1 TPS ≥1%
+MILD,14,AML_TARGETED_NEW,NCT02993523,HR,0.66,.52,.85,0.58,0.465,0.723,outcome_analyses,Overall survival in 1L unfit AML
+MILD,14,IO_CHEMO_NSCLC_1L,NCT02775435,HR,0.64,.49,.85,0.56,0.45,0.7,outcome_analyses,"Overall survival (primary, pembro+chemo vs chemo, HR)"
+MILD,13,ADJUVANT_IO_PAN_TUMOR,NCT04221945,HR,0.81,.66,.99,0.72,0.59,0.87,outcome_analyses,PFS in cervical CRT
+MILD,13,GASTRIC_FRONTLINE_IO_NMA,NCT02872116,HR,0.8,.68,.94,0.71,0.59,0.86,outcome_analyses,OS CheckMate-649
+MILD,13,OSIMERTINIB_EGFR_NSCLC,NCT02511106,HR,0.2,.14,.3,0.23,0.18,0.3,outcome_analyses,Disease-free survival (primary; HR vs placebo)
+MILD,13,PD1_RCC_1L,NCT02684006,HR,0.69,.56,.84,0.61,0.475,0.79,outcome_analyses,PFS in PD-L1+ population
+MILD,12,ANTI_PD1_GASTRIC,NCT03653507,HR,0.77,.62,.97,0.689,0.552,0.86,outcome_analyses,OS in CLDN18.2+ 1L gastric
+MILD,12,CERVICAL_CANCER_IO_BROAD,NCT03635567,HR,0.65,.5,.81,0.58,0.47,0.71,outcome_analyses,OS in 1L PD-L1 CPS ≥1
+MILD,12,COPD_BIOLOGICS_BROAD,NCT02138916,RR,0.93,.79,1.1,0.83,0.69,1.0,outcome_analyses,Annualized exacerbation rate (NEGATIVE)
+MILD,11,DOAC_AF,NCT00403767,HR,0.88,.75,1.03,0.79,0.66,0.96,outcome_analyses,"Stroke or systemic embolism (primary, on-treatment)"
+MILD,11,OVARIAN_PARP,NCT03522246,HR,0.52,.4,.68,0.47,0.31,0.72,outcome_analyses,PFS in 1L HRD subgroup
+MILD,10,ACALABRUTINIB_CLL,NCT02970318,HR,0.28,.2,.38,0.31,0.2,0.49,outcome_analyses,"IRC-assessed progression-free survival (primary, acalabrutinib vs investigator c"
+MILD,10,ANTI_PDL1_BLADDER,NCT02853305,HR,0.86,.72,1.02,0.78,0.65,0.93,outcome_analyses,OS in 1L combination (NEGATIVE)
+MILD,10,CHECKPOINT_ESOPHAGEAL_SCC,NCT02564263,HR,0.69,.52,.93,0.77,0.63,0.96,outcome_analyses,OS in PD-L1 CPS ≥10 ESCC subgroup
+MILD,10,SCLC_IO,NCT03066778,HR,0.8,.64,.98,0.73,0.6,0.88,outcome_analyses,PFS in 1L ES-SCLC
+MILD,9,CHECKPOINT_MELANOMA_1L,NCT01844505,HR,0.52,.43,.64,0.57,0.43,0.76,outcome_analyses,Overall survival (6.5y follow-up)
+MILD,9,HFpEF_DRUGS_NMA,NCT01920711,HR,0.87,.75,1.01,0.9531,0.7863,1.1551,outcome_analyses,Composite total HF hosp + CV death
+MILD,8,ADJUVANT_IO_MELANOMA,NCT02388906,HR,0.65,.51,.83,0.71,0.6,0.86,outcome_analyses,Recurrence-free survival (primary; HR vs ipilimumab)
+MILD,8,ANTI_PD1_GASTRIC,NCT02494583,HR,0.91,.74,1.1,0.84,0.7,1.02,outcome_analyses,OS pembro mono vs chemo (CPS ≥1)
+MILD,8,ANTI_PD1_GASTRIC,NCT03777657,HR,0.8,.66,.97,0.74,0.59,0.94,outcome_analyses,OS in PD-L1 TAP ≥5% (1L gastric)
+MILD,8,ANTI_TIGIT_TUMORS,NCT04256421,HR,1.02,.84,1.24,1.11,0.89,1.38,outcome_analyses,OS in 1L SCLC (NEGATIVE)
+MILD,8,HEAD_NECK_IO_BROAD,NCT03765918,HR,0.67,.51,.88,0.73,0.58,0.92,outcome_analyses,EFS in perioperative HNSCC
+MILD,8,IO_CHEMO_NSCLC_1L,NCT02578680,HR,0.56,.45,.7,0.52,0.43,0.64,outcome_analyses,"Overall survival (primary, pembro+chemo vs chemo, HR)"
+MILD,8,NEOADJUVANT_IO_BREAST,NCT03498716,HR,1.02,.85,1.24,1.11,0.87,1.42,outcome_analyses,iDFS in TNBC adjuvant (NEGATIVE)
+MILD,8,SGLT2_BROAD_OUTCOMES_NMA,NCT01032629,HR,0.86,.75,.97,0.93,0.78,1.12,outcome_analyses,3P-MACE CANVAS
+MILD,8,T1D_CLOSED_LOOP_NMA,NCT03844789,MD,11.0,9,13,12.0,6.2422,17.7578,outcome_measurements_mean_arms,TIR change 6mo (iDCL)
+MILD,7,AML_TARGETED_NEW,NCT02577406,HR,0.92,.73,1.16,0.86,0.67,1.1,outcome_analyses,OS in R/R IDH2+ AML (NEGATIVE)
+MILD,7,GASTRIC_FRONTLINE_IO_NMA,NCT03615326,HR,0.78,.69,.89,0.73,0.61,0.87,outcome_analyses,OS KN-859 pembro+chemo
+MILD,7,NPC_NASOPHARYNGEAL_IO,NCT02611960,HR,0.84,.62,1.13,0.9,0.67,1.19,outcome_analyses,OS in 2L recurrent/metastatic NPC
+MILD,7,VENETOCLAX_AML,NCT03069352,HR,0.7,.5,.98,0.749,0.524,1.071,outcome_analyses,Overall survival (6-month add-on primary)
+MILD,6,ADJUVANT_IO_PAN_TUMOR,NCT02504372,HR,0.76,.63,.91,0.81,0.68,0.96,outcome_analyses,DFS in stage IB-IIIA NSCLC
+MILD,6,TROP2_ADC_BROAD,NCT02574455,HR,0.41,.32,.52,0.387,0.305,0.492,outcome_analyses,PFS in metastatic TNBC

--- a/scripts/source_disagreement_report.py
+++ b/scripts/source_disagreement_report.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+"""Triage report: app effect value vs CT.gov source, where they disagree.
+
+For every trial whose non-null effect (publishedHR) disagrees with the
+source-verified value in outputs/pmid_resolver/nct_continuous.json by >5%, and
+where the measures match (outcome estimandType == source kind), emit a row with
+both values, both CIs, the outcome title, and a category:
+
+  SIGNFLIP    opposite sign (MD/RD) -- direction differs
+  RECIPROCAL  ratio ~= 1/source -- CT.gov posted the inverse comparison
+  EXTREME     >100% relative difference
+  MODERATE    25-100%
+  MILD        5-25%
+
+IMPORTANT -- this is a REVIEW aid, not an auto-fix list. Empirically most
+disagreements are NOT app errors: CT.gov's posted analysis is frequently a
+different outcome / timepoint / arm / parameterization, or the inverse
+direction, and the app value is the correct published primary (e.g. T1D
+TIR +12% vs a 0.19 source; gastric OS HR 0.82 vs a 1.27 inverse). Correcting
+these to the source would re-introduce errors. Genuine fixes require per-trial
+verification against the SAME outcome in the primary publication.
+
+Usage: python scripts/source_disagreement_report.py [--out outputs/source_disagreements.csv]
+"""
+from __future__ import annotations
+import argparse
+import csv
+import glob
+import importlib.util
+import json
+import os
+import re
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "dia", os.path.join(REPO, "scripts", "data_integrity_audit.py"))
+dia = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dia)
+CONT = json.load(open(os.path.join(REPO, "outputs", "pmid_resolver", "nct_continuous.json"),
+                     encoding="utf-8"))
+
+
+def outcome_field(obj, name):
+    tail = obj.split("allOutcomes", 1)
+    if len(tail) < 2:
+        return None
+    m = re.search(name + r':"([^"]+)"', tail[1])
+    return m.group(1) if m else None
+
+
+def categorize(est, app, src, rel):
+    if est in ("MD", "SMD", "WMD", "RD") and abs(app) > 1e-6 and abs(src) > 1e-6 and (app < 0) != (src < 0):
+        return "SIGNFLIP"
+    if est in ("HR", "OR", "RR", "IRR") and app > 0 and src > 0 and abs(app - 1.0 / src) / max(1e-9, 1.0 / src) < 0.1:
+        return "RECIPROCAL"
+    if rel > 1.0:
+        return "EXTREME"
+    if rel > 0.25:
+        return "MODERATE"
+    return "MILD"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="outputs/source_disagreements.csv")
+    args = ap.parse_args()
+
+    rows = []
+    seen = set()
+    for p in sorted(glob.glob(os.path.join(REPO, "*_REVIEW*.html"))):
+        html = open(p, encoding="utf-8", errors="replace").read()
+        for key, obj in dia.find_trial_objects(html):
+            app = dia.as_num(dia.field(obj, "publishedHR"))
+            if app is None:
+                continue
+            nct = key.split("_")[0]
+            e = CONT.get(nct)
+            if not e or e.get("effect") is None:
+                continue
+            est = (outcome_field(obj, "estimandType") or "").upper()
+            if est != str(e.get("kind", "")).upper():
+                continue  # only compare like-for-like measures
+            src = e["effect"]
+            rel = abs(app - src) / max(1e-9, abs(src))
+            if rel <= 0.05 or (nct, est) in seen:
+                continue
+            seen.add((nct, est))
+            rows.append({
+                "cat": categorize(est, app, src, rel),
+                "rel_pct": round(rel * 100),
+                "app": os.path.basename(p).replace("_AUTO_FULL_REVIEW.html", "").replace("_REVIEW.html", ""),
+                "nct": nct, "est": est,
+                "app_val": app, "app_lci": dia.field(obj, "hrLCI"), "app_uci": dia.field(obj, "hrUCI"),
+                "src_val": src, "src_lci": e.get("lci"), "src_uci": e.get("uci"),
+                "src_origin": e.get("source", ""),
+                "outcome_title": (outcome_field(obj, "title") or "")[:80],
+            })
+    order = {"SIGNFLIP": 4, "RECIPROCAL": 3, "EXTREME": 2, "MODERATE": 1, "MILD": 0}
+    rows.sort(key=lambda r: (-order[r["cat"]], -r["rel_pct"]))
+
+    out = os.path.join(REPO, args.out)
+    with open(out, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        w.writerows(rows)
+    from collections import Counter
+    c = Counter(r["cat"] for r in rows)
+    print(f"{len(rows)} measure-matched disagreements (>5%). By category: {dict(c)}")
+    print(f"Wrote {args.out}")
+    print("NOTE: review aid only -- most disagreements are different-outcome/inverse, "
+          "not app errors. Do not bulk-correct to source.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
You asked me to tackle the values that disagree with CT.gov. I investigated all of them and the honest conclusion is: **this should not be an auto-fix** — bulk-correcting to the CT.gov source would re-introduce errors (the same class of mistake as the earlier continuous-as-ratio null).

## What this adds (no data changed)
- `scripts/source_disagreement_report.py` + `outputs/source_disagreements.csv`: the **84** trials whose non-null effect disagrees with the source value by >5%, measure-matched, categorized with outcome titles and both CIs.

## Categories: SIGNFLIP 6 · RECIPROCAL 5 · EXTREME 5 · MODERATE 23 · MILD 45

## Why most are NOT app errors (spot-verified against the published primaries)
- **RECIPROCAL (5):** CT.gov posted the *inverse* comparison; the app is correct (gastric `OS HR 0.82` vs source `1.27` = 1/0.82).
- **EXTREME (5):** the app value is the correct published primary; the source is a *different outcome* (T1D `TIR +12%` vs source `0.19`; prostate `OS HR 0.63` vs source `0.28` = a different endpoint). Auto-"fixing" would corrupt correct data.
- **SIGNFLIP (6):** mostly outcome-type mismatches — the app value has a **multiplicative CI (a responder OR)** mislabeled `estimandType:"MD"`, while the source is the continuous mean-change (a *different outcome*). e.g. migraine `2.04` (responder OR) vs source `−1.4` (MMD change); MG-ADL `2.29 [1.39,3.76]` (log-symmetric → OR) vs source `−2.09` (MD change).
- **MODERATE/MILD (68):** overwhelmingly oncology HRs differing 5–40% — OS vs PFS, different data cuts, different arms.

## Recommendation
Genuine fixes require per-trial verification against the **same outcome** in the primary publication — this CSV is the input to that source-verified curation. I can deep-verify any specific subset you point me at, but I won't bulk-mutate based on a source that is frequently a different outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)