### PR TITLE
Cross-app check: clarify mismatch != error (no data changes this round)

### DIFF
--- a/scripts/cross_app_value_check.py
+++ b/scripts/cross_app_value_check.py
@@ -8,10 +8,23 @@ source-verified value (outputs/pmid_resolver/nct_continuous.json) within
 tolerance, but another app disagrees by >REL. The source-matching value is the
 corroborated reference; the disagreeing app(s) are flagged as likely-wrong.
 
-This reliably surfaces the "dedicated single-drug app is right, broad/NMA app is
-wrong" pattern (e.g. RAISE, SIRIUS, EMBARK) without a per-trial literature
-lookup -- the agreement of an independent app AND the registry is strong
-evidence. Still verify against the primary before correcting.
+This surfaces cross-app value inconsistencies, but a "mismatch" is NOT
+necessarily an error and the "reference" (the source-matching value) is NOT
+authoritative. Two distinct cases produce flags:
+
+  * GENUINE ERROR -- one app has a wrong value for the SAME outcome (SIRIUS
+    OCS-OR, EMBARK NSAA-MD, RAISE MG-ADL: the broad app was wrong, the dedicated
+    app + registry right).
+  * DIFFERENT OUTCOME -- the trial has multiple primaries and different apps
+    report different ones, each correct. Verified example: ECZTRA-1 tralokinumab
+    (NCT03131648, BJD 10.1111/bjd.19574) has dual primaries; the broad app
+    reports EASI-75 as OR 2.28 (published 25.0% vs 12.7% => OR ~2.29) and the
+    dedicated app reports IGA 0/1 as RD 8.6 pts (published difference 8.6 pts) --
+    BOTH correct, just different endpoints. The cross-check still flags it.
+
+So this is a TRIAGE aid only. ALWAYS verify against the primary publication's
+stated outcome -- including WHICH endpoint each app is reporting -- before
+changing anything, and never bulk-apply the reference value.
 
 Usage: python scripts/cross_app_value_check.py [--rel 0.05]
 """


### PR DESCRIPTION
This round verified the dermatology/responder cross-app candidates and found **no value errors to fix** — they're legitimate *different-outcome* representations. Documenting that finding in the tool so its output isn't misused.

## What I verified (no changes made)
- **ECZTRA‑1 tralokinumab** (NCT03131648, BJD [DOI](https://doi.org/10.1111/bjd.19574)): the trial has **dual primaries**. The broad app reports **EASI‑75 as OR 2.28** (published 25.0% vs 12.7% → OR ≈ 2.29 ✓); the dedicated app reports **IGA 0/1 as RD 8.6 pts** (published difference 8.6 pts ✓). **Both correct** — the cross-check flagged them only because they share an NCT.
- **PBC / ELATIVE** (last round, [DOI](https://doi.org/10.1056/NEJMoa2306185)): broad app `13.49` ≈ published response RR (51%/4% ≈ 13.5); the dedicated/source `37.562` is the questionable one — so the cross-check "reference" was again *not* authoritative.

## Tool change
Updated `scripts/cross_app_value_check.py` docstring: a mismatch has two causes (genuine same-outcome error **or** different-endpoint representation), the source-matching "reference" is **not** authoritative, and its output must never be bulk-applied — each candidate needs primary-source verification of *which endpoint* each app reports.

This prevents the exact corruption that auto-applying it would cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)